### PR TITLE
217199-post-check-endpoint-working-families

### DIFF
--- a/CheckYourEligibility.API.Tests/CheckYourEligibility.API.Tests.csproj
+++ b/CheckYourEligibility.API.Tests/CheckYourEligibility.API.Tests.csproj
@@ -11,21 +11,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.2"/>
-        <PackageReference Include="AutoFixture" Version="4.18.1"/>
-        <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1"/>
-        <PackageReference Include="AutoFixture.Idioms" Version="4.18.1"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
-        <PackageReference Include="NUnit" Version="4.1.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
-        <PackageReference Include="Moq" Version="4.20.70"/>
+        <PackageReference Include="FluentAssertions" Version="6.12.2" />
+        <PackageReference Include="AutoFixture" Version="4.18.1" />
+        <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
+        <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageReference Include="NUnit" Version="4.1.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="6.1.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\CheckYourEligibility.API\CheckYourEligibility.API.csproj"/>
+        <ProjectReference Include="..\CheckYourEligibility.API\CheckYourEligibility.API.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/CheckYourEligibility.API/Boundary/Requests/CheckEligibilityRequest.cs
+++ b/CheckYourEligibility.API/Boundary/Requests/CheckEligibilityRequest.cs
@@ -13,6 +13,7 @@ public class CheckEligibilityRequestDataBase : IEligibilityServiceType
         get => baseType;
         set => baseType = value != CheckEligibilityType.None ? value : CheckEligibilityType.FreeSchoolMeals;
     }
+	
 }
 
 public interface IEligibilityServiceType
@@ -24,19 +25,16 @@ public interface IEligibilityServiceType
 public class CheckEligibilityRequestData : CheckEligibilityRequestDataBase
 {
     public string? NationalInsuranceNumber { get; set; }
-
-    public string LastName { get; set; }
-
+    public string? LastName { get; set; }
     public string DateOfBirth { get; set; }
-
-    public string? NationalAsylumSeekerServiceNumber { get; set; }
+    public string? NationalAsylumSeekerServiceNumber { get; set; } 
+    public string? EligibilityCode { get; set; }
 }
 
 public class CheckEligibilityRequestBulkData : CheckEligibilityRequestData
 {
     public string? ClientIdentifier { get; set; }
 }
-
 public class CheckEligibilityRequest
 {
     public CheckEligibilityRequestData? Data { get; set; }

--- a/CheckYourEligibility.API/Boundary/Requests/CheckEligibilityRequest.cs
+++ b/CheckYourEligibility.API/Boundary/Requests/CheckEligibilityRequest.cs
@@ -1,4 +1,6 @@
 ﻿using CheckYourEligibility.API.Domain.Enums;
+using Newtonsoft.Json;
+using Swashbuckle.AspNetCore.Filters;
 
 namespace CheckYourEligibility.API.Boundary.Requests;
 
@@ -22,6 +24,7 @@ public interface IEligibilityServiceType
 
 #region FreeSchoolMeals Type
 
+[JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
 public class CheckEligibilityRequestData : CheckEligibilityRequestDataBase
 {
     public string? NationalInsuranceNumber { get; set; }
@@ -35,9 +38,45 @@ public class CheckEligibilityRequestBulkData : CheckEligibilityRequestData
 {
     public string? ClientIdentifier { get; set; }
 }
+
 public class CheckEligibilityRequest
 {
     public CheckEligibilityRequestData? Data { get; set; }
+}
+
+public class CheckWFModelExample : IExamplesProvider<CheckEligibilityRequest>
+{
+    public CheckEligibilityRequest GetExamples() {
+        return new CheckEligibilityRequest
+        {
+            Data = new CheckEligibilityRequestData
+            {
+                Type = CheckEligibilityType.WorkingFamilies,
+                NationalInsuranceNumber = "AB123456C",
+                NationalAsylumSeekerServiceNumber = null,
+                LastName = null,
+                DateOfBirth = "2024-01-01",
+                EligibilityCode = "50012345678"
+            }
+        };
+    }
+}
+public class CheckFSMModelExample : IExamplesProvider<CheckEligibilityRequest>
+{
+    public CheckEligibilityRequest GetExamples()
+    {
+        return new CheckEligibilityRequest
+        {
+            Data = new CheckEligibilityRequestData
+            {
+                NationalInsuranceNumber = "AB123456C",
+                NationalAsylumSeekerServiceNumber = "AB123456C",
+                LastName = "Smith",
+                DateOfBirth = "2024-01-01",
+                EligibilityCode = null
+            }
+        };
+    }
 }
 
 public class CheckEligibilityRequestBulk

--- a/CheckYourEligibility.API/CheckYourEligibility.API.csproj
+++ b/CheckYourEligibility.API/CheckYourEligibility.API.csproj
@@ -43,6 +43,7 @@
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="6.1.0" />
         <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
         <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     </ItemGroup>

--- a/CheckYourEligibility.API/Controllers/EligibilityController.cs
+++ b/CheckYourEligibility.API/Controllers/EligibilityController.cs
@@ -184,6 +184,28 @@ public class EligibilityCheckController : BaseController
             return BadRequest(new ErrorResponse { Errors = ex.Errors });
         }
     }
+    /// <summary>
+    ///     Posts the array of FSM checks
+    /// </summary>
+    /// <param name="model"></param>
+    /// <returns></returns>
+    [ProducesResponseType(typeof(CheckEligibilityResponseBulk), (int)HttpStatusCode.Accepted)]
+    [ProducesResponseType(typeof(ErrorResponse), (int)HttpStatusCode.BadRequest)]
+    [Consumes("application/json", "application/vnd.api+json;version=1.0")]
+    [HttpPost("/bulk-check/working-families")]
+    [Authorize(Policy = PolicyNames.RequireBulkCheckScope)]
+    public async Task<ActionResult> CheckEligibilityBulkWF([FromBody] CheckEligibilityRequestBulk model)
+    {
+        try
+        {
+            var result = await _checkEligibilityBulkUseCase.Execute(model, CheckEligibilityType.WorkingFamilies, _bulkUploadRecordCountLimit);
+            return new ObjectResult(result) { StatusCode = StatusCodes.Status202Accepted };
+        }
+        catch (ValidationException ex)
+        {
+            return BadRequest(new ErrorResponse { Errors = ex.Errors });
+        }
+    }
 
     /// <summary>
     ///     Posts the array of FSM checks

--- a/CheckYourEligibility.API/Controllers/EligibilityController.cs
+++ b/CheckYourEligibility.API/Controllers/EligibilityController.cs
@@ -8,6 +8,7 @@ using CheckYourEligibility.API.Gateways.Interfaces;
 using CheckYourEligibility.API.UseCases;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Filters;
 using System.Net;
 using NotFoundException = CheckYourEligibility.API.Domain.Exceptions.NotFoundException;
 using ValidationException = CheckYourEligibility.API.Domain.Exceptions.ValidationException;
@@ -94,6 +95,7 @@ public class EligibilityCheckController : BaseController
     /// </summary>
     /// <param name="model"></param>
     /// <remarks>If the check has already been submitted, then the stored Hash is returned</remarks>
+    [SwaggerRequestExample(typeof(CheckEligibilityRequest), typeof(CheckFSMModelExample))]
     [ProducesResponseType(typeof(CheckEligibilityResponse), (int)HttpStatusCode.Accepted)]
     [ProducesResponseType(typeof(ErrorResponse), (int)HttpStatusCode.BadRequest)]
     [Consumes("application/json", "application/vnd.api+json;version=1.0")]
@@ -165,11 +167,13 @@ public class EligibilityCheckController : BaseController
     /// Posts a WF Eligibility Check to the processing queue
     /// </summary>
     /// <param name="model"></param>
-    /// <remarks>If the check has already been submitted, then the stored Hash is returned</remarks>
+    /// <remarks>If the check has already been submitted, then the stored Hash is returned</remarks> 
+    [HttpPost("/check/working-families")]
+    [Consumes("application/json", "application/vnd.api+json;version=1.0")]
+    [SwaggerRequestExample(typeof(CheckEligibilityRequest),typeof(CheckWFModelExample))]
     [ProducesResponseType(typeof(CheckEligibilityResponse), (int)HttpStatusCode.Accepted)]
     [ProducesResponseType(typeof(ErrorResponse), (int)HttpStatusCode.BadRequest)]
-    [Consumes("application/json", "application/vnd.api+json;version=1.0")]
-    [HttpPost("/check/working-families")]
+
     [Authorize(Policy = PolicyNames.RequireCheckScope)]
     public async Task<ActionResult> CheckEligibilityWF(
         [FromBody] CheckEligibilityRequest model)

--- a/CheckYourEligibility.API/Domain/Constants/ErrorMessages/ApplicationValidationMessages.cs
+++ b/CheckYourEligibility.API/Domain/Constants/ErrorMessages/ApplicationValidationMessages.cs
@@ -13,7 +13,7 @@ public static class ValidationMessages
     public const string FirstName = "FirstName is required";
     public const string ChildLastName = "Child LastName is required";
     public const string ChildFirstName = "Child FirstName is required";
-    public const string NI = "Enter a National Insurance number that is 2 letters, 6 numbers, then A, B, C or D, like QQ 12 34 56 C";
+    public const string NI = "Invalid National Insurance Number";
     public const string NI_or_NASS = "National Insurance Number or National Asylum Seeker Service Number is required";
     public const string EligibilityCode = "Eligibility code must be 11 digits long";
 }

--- a/CheckYourEligibility.API/Domain/Constants/ErrorMessages/ApplicationValidationMessages.cs
+++ b/CheckYourEligibility.API/Domain/Constants/ErrorMessages/ApplicationValidationMessages.cs
@@ -13,6 +13,7 @@ public static class ValidationMessages
     public const string FirstName = "FirstName is required";
     public const string ChildLastName = "Child LastName is required";
     public const string ChildFirstName = "Child FirstName is required";
-    public const string NI = "Invalid National Insurance Number";
+    public const string NI = "Enter a National Insurance number that is 2 letters, 6 numbers, then A, B, C or D, like QQ 12 34 56 C";
     public const string NI_or_NASS = "National Insurance Number or National Asylum Seeker Service Number is required";
+    public const string EligibilityCode = "Eligibility code must be 11 digits long";
 }

--- a/CheckYourEligibility.API/Domain/Enums/CheckEligibilityType.cs
+++ b/CheckYourEligibility.API/Domain/Enums/CheckEligibilityType.cs
@@ -12,5 +12,6 @@ public enum CheckEligibilityType
     None = 0,
     [Description("Free School Meals")] FreeSchoolMeals,
     EarlyYearPupilPremium,
-    TwoYearOffer
+    TwoYearOffer,
+    WorkingFamilies
 }

--- a/CheckYourEligibility.API/Domain/Enums/CheckProcessData.cs
+++ b/CheckYourEligibility.API/Domain/Enums/CheckProcessData.cs
@@ -8,6 +8,8 @@ public class CheckProcessData
 
     public string LastName { get; set; }
 
+    public string EligibilityCode { get; set; }
+
     public string DateOfBirth { get; set; }
 
     public string? NationalAsylumSeekerServiceNumber { get; set; }

--- a/CheckYourEligibility.API/Domain/Validation/CheckEligibilityRequestDataValidator.cs
+++ b/CheckYourEligibility.API/Domain/Validation/CheckEligibilityRequestDataValidator.cs
@@ -2,6 +2,7 @@
 
 using CheckYourEligibility.API.Boundary.Requests;
 using CheckYourEligibility.API.Domain.Constants.ErrorMessages;
+using CheckYourEligibility.API.Domain.Enums;
 using CheckYourEligibility.API.Domain.Validation;
 using FluentValidation;
 
@@ -11,29 +12,44 @@ public class CheckEligibilityRequestDataValidator : AbstractValidator<CheckEligi
 {
     public CheckEligibilityRequestDataValidator()
     {
-        RuleFor(x => x.LastName)
-            .Must(DataValidation.BeAValidName)
-            .WithMessage(ValidationMessages.LastName);
 
         RuleFor(x => x.DateOfBirth)
             .NotEmpty()
             .Must(DataValidation.BeAValidDate)
             .WithMessage(ValidationMessages.DOB);
 
-        When(x => !string.IsNullOrEmpty(x.NationalInsuranceNumber), () =>
+        When(x => x.Type == CheckEligibilityType.WorkingFamilies, () =>
         {
-            RuleFor(x => x.NationalAsylumSeekerServiceNumber)
-                .Empty()
-                .WithMessage(ValidationMessages.NI_and_NASS);
             RuleFor(x => x.NationalInsuranceNumber)
                 .NotEmpty()
                 .Must(DataValidation.BeAValidNi)
                 .WithMessage(ValidationMessages.NI);
+            RuleFor(x => x.EligibilityCode)
+                .NotEmpty()
+                .When(x => x.Type == CheckEligibilityType.WorkingFamilies)
+                .Must(DataValidation.BeValidEligibilityCode)
+                .WithMessage(ValidationMessages.EligibilityCode);
         }).Otherwise(() =>
         {
-            RuleFor(x => x.NationalAsylumSeekerServiceNumber)
-                .NotEmpty()
-                .WithMessage(ValidationMessages.NI_or_NASS);
+            RuleFor(x => x.LastName)
+           .Must(DataValidation.BeAValidName)
+           .WithMessage(ValidationMessages.LastName);
+
+            When(x => !string.IsNullOrEmpty(x.NationalInsuranceNumber), () =>
+            {
+                RuleFor(x => x.NationalAsylumSeekerServiceNumber)
+                    .Empty()
+                    .WithMessage(ValidationMessages.NI_and_NASS);
+                RuleFor(x => x.NationalInsuranceNumber)
+                    .Must(DataValidation.BeAValidNi)
+                    .WithMessage(ValidationMessages.NI);
+            }).Otherwise(() =>
+            {
+                RuleFor(x => x.NationalAsylumSeekerServiceNumber)
+                    .NotEmpty()
+                    .WithMessage(ValidationMessages.NI_or_NASS);
+            });
         });
+
     }
 }

--- a/CheckYourEligibility.API/Domain/Validation/DataValidation.cs
+++ b/CheckYourEligibility.API/Domain/Validation/DataValidation.cs
@@ -8,13 +8,21 @@ internal static class DataValidation
     internal static bool BeAValidNi(string? value)
     {
         if (string.IsNullOrWhiteSpace(value)) return false;
+        value = value.ToUpper();
         var regexString =
             @"^(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)(?:[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z])(?:\s*\d\s*){6}([A-D]|\s)$";
         var rg = new Regex(regexString);
         var res = rg.Match(value);
         return res.Success;
     }
-
+    internal static bool BeValidEligibilityCode(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        var regexString = @"^\d{11}$";
+        var rg = new Regex(regexString);
+        var res = rg.Match(value);
+		return res.Success;
+    }
     internal static bool BeAValidDate(string value)
     {
         return DateTime.TryParseExact(value,

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -130,6 +130,7 @@ public class CheckEligibilityGateway : BaseGateway, ICheckEligibility
                 case CheckEligibilityType.FreeSchoolMeals:
                 case CheckEligibilityType.TwoYearOffer:
                 case CheckEligibilityType.EarlyYearPupilPremium:
+                case CheckEligibilityType.WorkingFamilies:
                     {
                         await Process_StandardCheck(guid, auditDataTemplate, result, checkData);
                     }
@@ -422,6 +423,7 @@ public class CheckEligibilityGateway : BaseGateway, ICheckEligibility
             case CheckEligibilityType.FreeSchoolMeals:
             case CheckEligibilityType.TwoYearOffer:
             case CheckEligibilityType.EarlyYearPupilPremium:
+            case CheckEligibilityType.WorkingFamilies:
                 return GetCheckProcessDataType<CheckEligibilityRequestBulkData>(type, data);
             default:
                 throw new NotImplementedException($"Type:-{type} not supported.");

--- a/CheckYourEligibility.API/Gateways/HashGateway.cs
+++ b/CheckYourEligibility.API/Gateways/HashGateway.cs
@@ -83,10 +83,11 @@ public class HashGateway : BaseGateway, IHash
     /// <returns></returns>
     private string GetHash(CheckProcessData item)
     {
+        var key1 = item.Type != CheckEligibilityType.WorkingFamilies ? item.LastName.ToUpper() : item.EligibilityCode;
         var key = string.IsNullOrEmpty(item.NationalInsuranceNumber)
             ? item.NationalAsylumSeekerServiceNumber.ToUpper()
             : item.NationalInsuranceNumber.ToUpper();
-        var input = $"{item.LastName.ToUpper()}{key}{item.DateOfBirth}{item.Type}";
+        var input = $"{key1}{key}{item.DateOfBirth}{item.Type}";
         var inputBytes = Encoding.UTF8.GetBytes(input);
         var inputHash = SHA256.HashData(inputBytes);
         return Convert.ToHexString(inputHash);

--- a/CheckYourEligibility.API/Program.cs
+++ b/CheckYourEligibility.API/Program.cs
@@ -17,6 +17,7 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using Notify.Client;
 using Notify.Interfaces;
+using Swashbuckle.AspNetCore.Filters;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-GB");
@@ -136,8 +137,10 @@ builder.Services.AddSwaggerGen(c =>
 
     var filePath = Path.Combine(AppContext.BaseDirectory, "CheckYourEligibility.API.xml");
     c.IncludeXmlComments(filePath);
+    c.ExampleFilters();
 });
 
+builder.Services.AddSwaggerExamplesFromAssemblyOf<CheckEligibilityRequest>();
 // Register Database and other services
 builder.Services.AddDatabase(builder.Configuration);
 builder.Services.AddAzureClients(builder.Configuration);

--- a/CheckYourEligibility.API/Usecases/CheckEligibilityUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CheckEligibilityUseCase.cs
@@ -2,9 +2,7 @@ using CheckYourEligibility.API.Boundary.Requests;
 using CheckYourEligibility.API.Boundary.Responses;
 using CheckYourEligibility.API.Domain.Constants;
 using CheckYourEligibility.API.Domain.Enums;
-using CheckYourEligibility.API.Domain.Exceptions;
 using CheckYourEligibility.API.Gateways.Interfaces;
-using FeatureManagement.Domain.Validation;
 using FluentValidation;
 using ValidationException = CheckYourEligibility.API.Domain.Exceptions.ValidationException;
 
@@ -45,19 +43,17 @@ public class CheckEligibilityUseCase : ICheckEligibilityUseCase
 
     public async Task<CheckEligibilityResponse> Execute(CheckEligibilityRequest model, CheckEligibilityType routeType)
     {
-        
         if (model?.Data == null)
+        {
             throw new ValidationException(null, "Missing request data");
+        }
 
         var modelData = EligibilityModelFactory.CreateFromGeneric(model, routeType);
 
         if (modelData.Data != null)
         {
-            modelData.Data.NationalInsuranceNumber = modelData.Data.NationalInsuranceNumber?.ToUpper();
-            modelData.Data.NationalAsylumSeekerServiceNumber = modelData.Data.NationalAsylumSeekerServiceNumber?.ToUpper();
 
             var validationResults = _validator.Validate(modelData.Data);
-
             if (!validationResults.IsValid) throw new ValidationException(null, validationResults.ToString());
 
             // Execute the check


### PR DESCRIPTION
1.  Post check request for a single check for working families
2.  Post check request for a bulk check for working families
3.  Validation logic changes to accommodate new CheckEligibilityType - Working Families
4.  Adding new tests for controller around Working families , and new use case tests for success for new type Working families.
5. Introducing swagger examples to solution to avoid confusion around what is required for different types of post checks requests.

Story : https://dev.azure.com/dfe-gov-uk/Solutions%20Development/_boards/board/t/ECS/Stories?workitem=217199