### PR TITLE
217200 Working families check result endpoint

### DIFF
--- a/CheckYourEligibility.API.Tests/Controllers/EligibilityCheckControllerTests.cs
+++ b/CheckYourEligibility.API.Tests/Controllers/EligibilityCheckControllerTests.cs
@@ -142,7 +142,7 @@ public class EligibilityCheckControllerTests : TestBase.TestBase
     public async Task CheckEligibility_returns_bad_request_when_use_case_returns_invalid_result()
     {
         // Arrange
-        var request = _fixture.Create<CheckEligibilityRequest>();
+        var request = _fixture.Create<CheckEligibilityRequest<CheckEligibilityRequestData>>();
         var executionResult = new CheckEligibilityResponse();
 
         _mockCheckEligibilityUseCase.Setup(u => u.Execute(request, Domain.Enums.CheckEligibilityType.FreeSchoolMeals))
@@ -161,7 +161,7 @@ public class EligibilityCheckControllerTests : TestBase.TestBase
     public async Task CheckEligibility_returns_accepted_with_response_when_use_case_returns_valid_result()
     {
         // Arrange
-        var request = _fixture.Create<CheckEligibilityRequest>();
+        var request = _fixture.Create<CheckEligibilityRequest<CheckEligibilityRequestData>>();
         var statusResponse = _fixture.Create<CheckEligibilityResponse>();
         var executionResult = statusResponse;
 
@@ -247,7 +247,7 @@ public class EligibilityCheckControllerTests : TestBase.TestBase
     public async Task CheckEligibility_WF_returns_bad_request_when_use_case_returns_invalid_result()
     {
         // Arrange
-        var request = _fixture.Create<CheckEligibilityRequest>();
+        var request = _fixture.Create<CheckEligibilityRequest<CheckEligibilityRequestWorkingFamiliesData>>();
         _mockCheckEligibilityUseCase.Setup(u => u.Execute(request, Domain.Enums.CheckEligibilityType.WorkingFamilies))
         .ThrowsAsync(new ValidationException(null, "Validation error"));
 
@@ -266,7 +266,7 @@ public class EligibilityCheckControllerTests : TestBase.TestBase
     public async Task CheckEligibility_WF_returns_accepted_with_response_when_use_case_returns_valid_result()
     {
         // Arrange
-        var request = _fixture.Create<CheckEligibilityRequest>();
+        var request = _fixture.Create<CheckEligibilityRequest<CheckEligibilityRequestWorkingFamiliesData>>();
         var statusResponse = _fixture.Create<CheckEligibilityResponse>();
         var executionResult = statusResponse;
 

--- a/CheckYourEligibility.API.Tests/Usecases/CheckEligibilityBulkUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/CheckEligibilityBulkUseCaseTests.cs
@@ -4,7 +4,6 @@ using CheckYourEligibility.API.Domain.Constants;
 using CheckYourEligibility.API.Domain.Enums;
 using CheckYourEligibility.API.Gateways.Interfaces;
 using CheckYourEligibility.API.UseCases;
-using FeatureManagement.Domain.Validation;
 using FluentAssertions;
 using FluentValidation;
 using Microsoft.Extensions.Logging;
@@ -18,7 +17,7 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
     [SetUp]
     public void Setup()
     {
-        _mockValidator = new Mock<IValidator<CheckEligibilityRequestData>>();
+        _mockValidator = new Mock<IValidator<IEligibilityServiceType>>();
         _mockCheckGateway = new Mock<ICheckEligibility>(MockBehavior.Strict);
         _mockAuditGateway = new Mock<IAudit>(MockBehavior.Strict);
         _mockLogger = new Mock<ILogger<CheckEligibilityBulkUseCase>>(MockBehavior.Loose);
@@ -39,7 +38,7 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
     }
 
 
-    private Mock<IValidator<CheckEligibilityRequestData>> _mockValidator;
+    private Mock<IValidator<IEligibilityServiceType>> _mockValidator;
     private Mock<ICheckEligibility> _mockCheckGateway;
     private Mock<IAudit> _mockAuditGateway;
     private Mock<ILogger<CheckEligibilityBulkUseCase>> _mockLogger;

--- a/CheckYourEligibility.API/Boundary/Requests/CheckEligibilityRequest.cs
+++ b/CheckYourEligibility.API/Boundary/Requests/CheckEligibilityRequest.cs
@@ -15,65 +15,76 @@ public class CheckEligibilityRequestDataBase : IEligibilityServiceType
         get => baseType;
         set => baseType = value != CheckEligibilityType.None ? value : CheckEligibilityType.FreeSchoolMeals;
     }
-	
+    public string? NationalInsuranceNumber { get; set; }
+
 }
 
 public interface IEligibilityServiceType
 {
+    public CheckEligibilityType Type { get; set;}
 }
 
 #region FreeSchoolMeals Type
-
 [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
 public class CheckEligibilityRequestData : CheckEligibilityRequestDataBase
 {
-    public string? NationalInsuranceNumber { get; set; }
     public string? LastName { get; set; }
     public string DateOfBirth { get; set; }
     public string? NationalAsylumSeekerServiceNumber { get; set; } 
-    public string? EligibilityCode { get; set; }
-}
 
+}
+[JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
+public class CheckEligibilityRequestWorkingFamiliesData : CheckEligibilityRequestDataBase
+{
+    public string EligibilityCode { get; set; }
+    public string? ValidityStartDate { get; set; }
+    public string? ValidityEndDate { get; set; }
+    public string? GracePeriodEndDate { get; set; }  
+    public string? ParentLastName { get; set; }  
+    public string ChildDateOfBirth { get; set; }
+
+}
 public class CheckEligibilityRequestBulkData : CheckEligibilityRequestData
 {
     public string? ClientIdentifier { get; set; }
 }
 
-public class CheckEligibilityRequest
+public class CheckEligibilityRequest<T> where T : IEligibilityServiceType
 {
-    public CheckEligibilityRequestData? Data { get; set; }
+    public T? Data { get; set; }
 }
 
-public class CheckWFModelExample : IExamplesProvider<CheckEligibilityRequest>
+public class CheckWFModelExample : IExamplesProvider<CheckEligibilityRequest<CheckEligibilityRequestWorkingFamiliesData>>
 {
-    public CheckEligibilityRequest GetExamples() {
-        return new CheckEligibilityRequest
+    public CheckEligibilityRequest<CheckEligibilityRequestWorkingFamiliesData> GetExamples() {
+        return new CheckEligibilityRequest<CheckEligibilityRequestWorkingFamiliesData>
         {
-            Data = new CheckEligibilityRequestData
+            Data = new CheckEligibilityRequestWorkingFamiliesData
             {
                 Type = CheckEligibilityType.WorkingFamilies,
                 NationalInsuranceNumber = "AB123456C",
-                NationalAsylumSeekerServiceNumber = null,
-                LastName = null,
-                DateOfBirth = "2024-01-01",
-                EligibilityCode = "50012345678"
+                ChildDateOfBirth = "2024-01-01",
+                EligibilityCode = "50012345678",
+                ParentLastName = null,
+                ValidityStartDate = null,
+                ValidityEndDate = null,
+                GracePeriodEndDate = null
             }
         };
     }
 }
-public class CheckFSMModelExample : IExamplesProvider<CheckEligibilityRequest>
+public class CheckFSMModelExample : IExamplesProvider<CheckEligibilityRequest<CheckEligibilityRequestData>>
 {
-    public CheckEligibilityRequest GetExamples()
+    public CheckEligibilityRequest<CheckEligibilityRequestData> GetExamples()
     {
-        return new CheckEligibilityRequest
+        return new CheckEligibilityRequest<CheckEligibilityRequestData>
         {
             Data = new CheckEligibilityRequestData
             {
                 NationalInsuranceNumber = "AB123456C",
                 NationalAsylumSeekerServiceNumber = "AB123456C",
                 LastName = "Smith",
-                DateOfBirth = "2024-01-01",
-                EligibilityCode = null
+                DateOfBirth = "2024-01-01"
             }
         };
     }
@@ -90,7 +101,7 @@ public class CheckEligibilityRequestBulk
 #endregion
 public static class EligibilityModelFactory
 {
-    public static CheckEligibilityRequest CreateFromGeneric(CheckEligibilityRequest model, CheckEligibilityType routeType)
+    public static CheckEligibilityRequest<T> CreateFromGeneric<T>(CheckEligibilityRequest<T> model, CheckEligibilityType routeType) where T : IEligibilityServiceType
     {
         if (model.Data.Type != routeType)
             model.Data.Type = routeType;

--- a/CheckYourEligibility.API/Boundary/Responses/CheckEligibilityItemResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/CheckEligibilityItemResponse.cs
@@ -1,8 +1,18 @@
-﻿namespace CheckYourEligibility.API.Boundary.Responses;
+﻿using Newtonsoft.Json;
 
-public class CheckEligibilityItem
-{
+namespace CheckYourEligibility.API.Boundary.Responses;
+
+public class CheckEligibilityItemBase {
     public string NationalInsuranceNumber { get; set; }
+
+    public string Status { get; set; }
+
+    public DateTime Created { get; set; }
+}
+
+[JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
+public class CheckEligibilityItem : CheckEligibilityItemBase
+{
 
     public string LastName { get; set; }
 
@@ -11,12 +21,13 @@ public class CheckEligibilityItem
     public string NationalAsylumSeekerServiceNumber { get; set; }
 
     public string? ClientIdentifier { get; set; }
+    public string ValidityStartDate { get; set; }
+    public string ValidityEndDate { get; set; }
+    public string GracePeriodEndDate { get; set; }
+    public string EligibilityCode { get; set; }
+    public string ParentLastName { get; set; }
 
-    public string Status { get; set; }
-
-    public DateTime Created { get; set; }
 }
-
 public class CheckEligibilityItemResponse
 {
     public CheckEligibilityItem Data { get; set; }

--- a/CheckYourEligibility.API/Controllers/EligibilityController.cs
+++ b/CheckYourEligibility.API/Controllers/EligibilityController.cs
@@ -95,14 +95,14 @@ public class EligibilityCheckController : BaseController
     /// </summary>
     /// <param name="model"></param>
     /// <remarks>If the check has already been submitted, then the stored Hash is returned</remarks>
-    [SwaggerRequestExample(typeof(CheckEligibilityRequest), typeof(CheckFSMModelExample))]
+    [SwaggerRequestExample(typeof(CheckEligibilityRequest<CheckEligibilityRequestData>), typeof(CheckFSMModelExample))]
     [ProducesResponseType(typeof(CheckEligibilityResponse), (int)HttpStatusCode.Accepted)]
     [ProducesResponseType(typeof(ErrorResponse), (int)HttpStatusCode.BadRequest)]
     [Consumes("application/json", "application/vnd.api+json;version=1.0")]
     [HttpPost("/check/free-school-meals")]
     [Authorize(Policy = PolicyNames.RequireCheckScope)]
     public async Task<ActionResult> CheckEligibilityFsm(
-        [FromBody] CheckEligibilityRequest model)
+        [FromBody] CheckEligibilityRequest<CheckEligibilityRequestData> model)
     {
         try
         {
@@ -126,7 +126,7 @@ public class EligibilityCheckController : BaseController
     [HttpPost("/check/two-year-offer")]
     [Authorize(Policy = PolicyNames.RequireCheckScope)]
     public async Task<ActionResult> CheckEligibility2yo(
-        [FromBody] CheckEligibilityRequest model)
+        [FromBody] CheckEligibilityRequest<CheckEligibilityRequestData> model)
     {
         try
         {
@@ -150,7 +150,7 @@ public class EligibilityCheckController : BaseController
     [HttpPost("/check/early-year-pupil-premium")]
     [Authorize(Policy = PolicyNames.RequireCheckScope)]
     public async Task<ActionResult> CheckEligibilityEypp(
-        [FromBody] CheckEligibilityRequest model)
+        [FromBody] CheckEligibilityRequest<CheckEligibilityRequestData> model)
     {
         try
         {
@@ -168,18 +168,18 @@ public class EligibilityCheckController : BaseController
     /// </summary>
     /// <param name="model"></param>
     /// <remarks>If the check has already been submitted, then the stored Hash is returned</remarks> 
-    [HttpPost("/check/working-families")]
-    [Consumes("application/json", "application/vnd.api+json;version=1.0")]
-    [SwaggerRequestExample(typeof(CheckEligibilityRequest),typeof(CheckWFModelExample))]
+    [SwaggerRequestExample(typeof(CheckEligibilityRequest<CheckEligibilityRequestWorkingFamiliesData>),typeof(CheckWFModelExample))]
     [ProducesResponseType(typeof(CheckEligibilityResponse), (int)HttpStatusCode.Accepted)]
     [ProducesResponseType(typeof(ErrorResponse), (int)HttpStatusCode.BadRequest)]
-
+    [HttpPost("/check/working-families")]
+    [Consumes("application/json", "application/vnd.api+json;version=1.0")]
     [Authorize(Policy = PolicyNames.RequireCheckScope)]
     public async Task<ActionResult> CheckEligibilityWF(
-        [FromBody] CheckEligibilityRequest model)
+        [FromBody] CheckEligibilityRequest<CheckEligibilityRequestWorkingFamiliesData> model)
     {
         try
         {
+
             var result = await _checkEligibilityUseCase.Execute(model, CheckEligibilityType.WorkingFamilies);
             return new ObjectResult(result) { StatusCode = StatusCodes.Status202Accepted };
         }

--- a/CheckYourEligibility.API/Domain/Enums/CheckEligibilityStatus.cs
+++ b/CheckYourEligibility.API/Domain/Enums/CheckEligibilityStatus.cs
@@ -8,5 +8,6 @@ public enum CheckEligibilityStatus
     parentNotFound,
     eligible,
     notEligible,
-    error
+    error,
+    notFound
 }

--- a/CheckYourEligibility.API/Domain/Enums/CheckProcessData.cs
+++ b/CheckYourEligibility.API/Domain/Enums/CheckProcessData.cs
@@ -7,9 +7,12 @@ public class CheckProcessData
     public string? NationalInsuranceNumber { get; set; }
 
     public string LastName { get; set; }
-
+    public string ParentLastName { get; set; }
+    
     public string EligibilityCode { get; set; }
-
+    public string ValidityStartDate { get; set; }
+    public string ValidityEndDate { get; set; }
+    public string GracePeriodEndDate { get; set; }
     public string DateOfBirth { get; set; }
 
     public string? NationalAsylumSeekerServiceNumber { get; set; }

--- a/CheckYourEligibility.API/Domain/Validation/CheckEligibilityRequestDataValidator.cs
+++ b/CheckYourEligibility.API/Domain/Validation/CheckEligibilityRequestDataValidator.cs
@@ -1,55 +1,60 @@
 ﻿// Ignore Spelling: Validator
-
 using CheckYourEligibility.API.Boundary.Requests;
 using CheckYourEligibility.API.Domain.Constants.ErrorMessages;
-using CheckYourEligibility.API.Domain.Enums;
 using CheckYourEligibility.API.Domain.Validation;
 using FluentValidation;
 
 namespace FeatureManagement.Domain.Validation;
 
-public class CheckEligibilityRequestDataValidator : AbstractValidator<CheckEligibilityRequestData>
+public class CheckEligibilityRequestDataValidator : AbstractValidator<IEligibilityServiceType>
 {
     public CheckEligibilityRequestDataValidator()
     {
 
-        RuleFor(x => x.DateOfBirth)
-            .NotEmpty()
-            .Must(DataValidation.BeAValidDate)
-            .WithMessage(ValidationMessages.DOB);
-
-        When(x => x.Type == CheckEligibilityType.WorkingFamilies, () =>
+        // Rules for FSM, EYPP, 2YO
+        When(x => x is CheckEligibilityRequestData, () =>
         {
-            RuleFor(x => x.NationalInsuranceNumber)
+            RuleFor(x => ((CheckEligibilityRequestData)x).LastName)
                 .NotEmpty()
-                .Must(DataValidation.BeAValidNi)
-                .WithMessage(ValidationMessages.NI);
-            RuleFor(x => x.EligibilityCode)
-                .NotEmpty()
-                .When(x => x.Type == CheckEligibilityType.WorkingFamilies)
-                .Must(DataValidation.BeValidEligibilityCode)
-                .WithMessage(ValidationMessages.EligibilityCode);
-        }).Otherwise(() =>
-        {
-            RuleFor(x => x.LastName)
-           .Must(DataValidation.BeAValidName)
-           .WithMessage(ValidationMessages.LastName);
+                .Must(DataValidation.BeAValidName)
+                .WithMessage(ValidationMessages.LastName);
 
-            When(x => !string.IsNullOrEmpty(x.NationalInsuranceNumber), () =>
+            RuleFor(x => ((CheckEligibilityRequestData)x).DateOfBirth)
+                .NotEmpty()
+                .Must(DataValidation.BeAValidDate)
+                .WithMessage(ValidationMessages.DOB);
+
+            When(x => !string.IsNullOrEmpty(((CheckEligibilityRequestData)x).NationalInsuranceNumber), () =>
             {
-                RuleFor(x => x.NationalAsylumSeekerServiceNumber)
+                RuleFor(x => ((CheckEligibilityRequestData)x).NationalAsylumSeekerServiceNumber)
                     .Empty()
                     .WithMessage(ValidationMessages.NI_and_NASS);
-                RuleFor(x => x.NationalInsuranceNumber)
+                RuleFor(x => ((CheckEligibilityRequestData)x).NationalInsuranceNumber)
                     .Must(DataValidation.BeAValidNi)
                     .WithMessage(ValidationMessages.NI);
             }).Otherwise(() =>
             {
-                RuleFor(x => x.NationalAsylumSeekerServiceNumber)
+                RuleFor(x => ((CheckEligibilityRequestData)x).NationalAsylumSeekerServiceNumber)
                     .NotEmpty()
                     .WithMessage(ValidationMessages.NI_or_NASS);
             });
         });
 
+        // Rules for Working families
+        When(x => x is CheckEligibilityRequestWorkingFamiliesData, () =>
+        {
+            RuleFor(x => ((CheckEligibilityRequestWorkingFamiliesData)x).EligibilityCode)
+                .NotEmpty()
+                .Must(DataValidation.BeAValidEligibilityCode)
+                .WithMessage(ValidationMessages.EligibilityCode);
+            RuleFor(x => ((CheckEligibilityRequestWorkingFamiliesData)x).ChildDateOfBirth)
+                .NotEmpty()
+                .Must(DataValidation.BeAValidDate)
+                .WithMessage(ValidationMessages.ChildDOB);
+            RuleFor(x => ((CheckEligibilityRequestWorkingFamiliesData)x).NationalInsuranceNumber)
+               .Must(DataValidation.BeAValidNi)
+               .WithMessage(ValidationMessages.NI);
+        });
     }
+
 }

--- a/CheckYourEligibility.API/Domain/Validation/CheckEligibilityRequestDataValidator.cs
+++ b/CheckYourEligibility.API/Domain/Validation/CheckEligibilityRequestDataValidator.cs
@@ -15,7 +15,6 @@ public class CheckEligibilityRequestDataValidator : AbstractValidator<IEligibili
         When(x => x is CheckEligibilityRequestData, () =>
         {
             RuleFor(x => ((CheckEligibilityRequestData)x).LastName)
-                .NotEmpty()
                 .Must(DataValidation.BeAValidName)
                 .WithMessage(ValidationMessages.LastName);
 

--- a/CheckYourEligibility.API/Domain/Validation/DataValidation.cs
+++ b/CheckYourEligibility.API/Domain/Validation/DataValidation.cs
@@ -15,7 +15,7 @@ internal static class DataValidation
         var res = rg.Match(value);
         return res.Success;
     }
-    internal static bool BeValidEligibilityCode(string? value)
+    internal static bool BeAValidEligibilityCode(string? value)
     {
         if (string.IsNullOrWhiteSpace(value)) return false;
         var regexString = @"^\d{11}$";

--- a/CheckYourEligibility.API/Domain/WorkingFamiliesEvent.cs
+++ b/CheckYourEligibility.API/Domain/WorkingFamiliesEvent.cs
@@ -1,0 +1,37 @@
+﻿// Ignore Spelling: Fsm
+
+using Azure.Messaging.EventGrid;
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CheckYourEligibility.API.Domain;
+
+[ExcludeFromCodeCoverage(Justification = "Data Model.")]
+public class WorkingFamiliesEvent
+{
+    public string WorkingFamiliesEventId { get; set; }
+    [Column(TypeName = "nchar(11)")] public string EligibilityCode { get; set; }
+    [Column(TypeName = "varchar(100)")] public string ChildFirstName { get; set; }
+
+    [Column(TypeName = "varchar(100)")] public string ChildLastName { get; set; }
+    public DateTime ChildDateOfBirth { get; set; }
+    [Column(TypeName = "varchar(100)")] public string ParentFirstName { get; set; }
+
+    [Column(TypeName = "varchar(100)")] public string ParentLastName { get; set; }
+
+    [Column(TypeName = "varchar(10)")] public string? ParentNationalInsuranceNumber { get; set; }
+
+    [Column(TypeName = "varchar(100)")] public string PartnerFirstName { get; set; }
+
+    [Column(TypeName = "varchar(100)")] public string PartnerLastName { get; set; }
+
+    [Column(TypeName = "varchar(10)")] public string? PartnerNationalInsuranceNumber { get; set; }
+
+    public DateTime ValidityStartDate { get; set; }
+    public DateTime ValidityEndDate { get; set; }
+    public DateTime DiscretionaryValidityStartDate { get; set; }
+    public DateTime GracePeriodEndDate { get; set; }
+
+
+}

--- a/CheckYourEligibility.API/Factories/MappingProfile.cs
+++ b/CheckYourEligibility.API/Factories/MappingProfile.cs
@@ -15,12 +15,10 @@ public class MappingProfile : Profile
 {
     public MappingProfile()
     {
-        CreateMap<CheckEligibilityRequestData, EligibilityCheck>()
+        CreateMap<IEligibilityServiceType, EligibilityCheck>()
             .ReverseMap();
-
         CreateMap<EligibilityCheck, CheckEligibilityItem>()
             .ReverseMap();
-
         CreateMap<ApplicationRequestData, Application>()
             .ForMember(dest => dest.ParentNationalInsuranceNumber,
                 opt => opt.MapFrom(src => src.ParentNationalInsuranceNumber))

--- a/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
+++ b/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
@@ -13,9 +13,8 @@ public class EligibilityCheckContext : DbContext, IEligibilityCheckContext
     public EligibilityCheckContext(DbContextOptions<EligibilityCheckContext> options) : base(options)
     {
     }
-
+    public virtual DbSet<WorkingFamiliesEvent> WorkingFamiliesEvents { get; set; }
     public virtual DbSet<ApplicationEvidence> ApplicationEvidence { get; set; }
-
     public virtual DbSet<EligibilityCheck> CheckEligibilities { get; set; }
     public virtual DbSet<FreeSchoolMealsHMRC> FreeSchoolMealsHMRC { get; set; }
     public virtual DbSet<FreeSchoolMealsHO> FreeSchoolMealsHO { get; set; }

--- a/CheckYourEligibility.API/Infrastructure/IEligibilityCheckContext.cs
+++ b/CheckYourEligibility.API/Infrastructure/IEligibilityCheckContext.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 
 public interface IEligibilityCheckContext
 {
+    DbSet<WorkingFamiliesEvent> WorkingFamiliesEvents { get; set; }
     DbSet<EligibilityCheck> CheckEligibilities { get; set; }
     DbSet<FreeSchoolMealsHMRC> FreeSchoolMealsHMRC { get; set; }
     DbSet<FreeSchoolMealsHO> FreeSchoolMealsHO { get; set; }

--- a/CheckYourEligibility.API/Migrations/20250707093143_WorkingFamiliesEvent.Designer.cs
+++ b/CheckYourEligibility.API/Migrations/20250707093143_WorkingFamiliesEvent.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CheckYourEligibility.API.Migrations
 {
     [DbContext(typeof(EligibilityCheckContext))]
-    partial class EligibilityCheckContextModelSnapshot : ModelSnapshot
+    [Migration("20250707093143_WorkingFamiliesEvent")]
+    partial class WorkingFamiliesEvent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CheckYourEligibility.API/Migrations/20250707093143_WorkingFamiliesEvent.cs
+++ b/CheckYourEligibility.API/Migrations/20250707093143_WorkingFamiliesEvent.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CheckYourEligibility.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class WorkingFamiliesEvent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WorkingFamiliesEvents",
+                columns: table => new
+                {
+                    WorkingFamiliesEventId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    EligibilityCode = table.Column<string>(type: "nchar(11)", nullable: false),
+                    ChildFirstName = table.Column<string>(type: "varchar(100)", nullable: false),
+                    ChildLastName = table.Column<string>(type: "varchar(100)", nullable: false),
+                    ChildDateOfBirth = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ParentFirstName = table.Column<string>(type: "varchar(100)", nullable: false),
+                    ParentLastName = table.Column<string>(type: "varchar(100)", nullable: false),
+                    ParentNationalInsuranceNumber = table.Column<string>(type: "varchar(10)", nullable: true),
+                    PartnerFirstName = table.Column<string>(type: "varchar(100)", nullable: false),
+                    PartnerLastName = table.Column<string>(type: "varchar(100)", nullable: false),
+                    PartnerNationalInsuranceNumber = table.Column<string>(type: "varchar(10)", nullable: true),
+                    ValidityStartDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ValidityEndDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DiscretionaryValidityStartDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    GracePeriodEndDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkingFamiliesEvents", x => x.WorkingFamiliesEventId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WorkingFamiliesEvents");
+        }
+    }
+}

--- a/CheckYourEligibility.API/Program.cs
+++ b/CheckYourEligibility.API/Program.cs
@@ -140,7 +140,7 @@ builder.Services.AddSwaggerGen(c =>
     c.ExampleFilters();
 });
 
-builder.Services.AddSwaggerExamplesFromAssemblyOf<CheckEligibilityRequest>();
+builder.Services.AddSwaggerExamplesFromAssemblyOf<IEligibilityServiceType>();
 // Register Database and other services
 builder.Services.AddDatabase(builder.Configuration);
 builder.Services.AddAzureClients(builder.Configuration);
@@ -175,7 +175,7 @@ builder.Services.AddScoped<IProcessEligibilityCheckUseCase, ProcessEligibilityCh
 builder.Services.AddScoped<IGetEligibilityCheckItemUseCase, GetEligibilityCheckItemUseCase>();
 builder.Services.AddScoped<ISendNotificationUseCase, SendNotificationUseCase>();
 
-builder.Services.AddScoped<IValidator<CheckEligibilityRequestData>, CheckEligibilityRequestDataValidator>();
+builder.Services.AddScoped<IValidator<IEligibilityServiceType>, CheckEligibilityRequestDataValidator>();
 
 builder.Services.AddTransient<INotificationClient>(x => new NotificationClient(builder.Configuration.GetValue<string>("Notify:Key")));
 builder.Services.AddTransient<INotificationClient>(x =>

--- a/CheckYourEligibility.API/Usecases/CheckEligibilityBulkUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CheckEligibilityBulkUseCase.cs
@@ -21,13 +21,13 @@ public interface ICheckEligibilityBulkUseCase
 public class CheckEligibilityBulkUseCase : ICheckEligibilityBulkUseCase
 
 {
-    private readonly IValidator<CheckEligibilityRequestData> _validator;
+    private readonly IValidator<IEligibilityServiceType> _validator;
     private readonly IAudit _auditGateway;
     private readonly ICheckEligibility _checkGateway;
     private readonly ILogger<CheckEligibilityBulkUseCase> _logger;
 
     public CheckEligibilityBulkUseCase(
-        IValidator<CheckEligibilityRequestData> validator,
+        IValidator<IEligibilityServiceType> validator,
         ICheckEligibility checkGateway,
         IAudit auditGateway,
         ILogger<CheckEligibilityBulkUseCase> logger)

--- a/CheckYourEligibility.API/Usecases/CheckEligibilityUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CheckEligibilityUseCase.cs
@@ -19,7 +19,7 @@ public interface ICheckEligibilityUseCase
     /// <param name="model">Eligibility check request</param>
     /// <param name="routeType">The type of eligibility check to perform</param>
     /// <returns>Check eligibility response or validation errors</returns>
-    Task<CheckEligibilityResponse> Execute(CheckEligibilityRequest model, CheckEligibilityType routeType);
+    Task<CheckEligibilityResponse> Execute<T>(CheckEligibilityRequest<T> model, CheckEligibilityType routeType) where T : IEligibilityServiceType;
 }
 
 public class CheckEligibilityUseCase : ICheckEligibilityUseCase
@@ -27,12 +27,12 @@ public class CheckEligibilityUseCase : ICheckEligibilityUseCase
     private readonly IAudit _auditGateway;
     private readonly ICheckEligibility _checkGateway;
     private readonly ILogger<CheckEligibilityUseCase> _logger;
-    private readonly IValidator<CheckEligibilityRequestData> _validator;
+    private readonly IValidator<IEligibilityServiceType> _validator;
 
     public CheckEligibilityUseCase(
         ICheckEligibility checkGateway,
         IAudit auditGateway,
-        IValidator<CheckEligibilityRequestData> validator,
+        IValidator<IEligibilityServiceType> validator,
         ILogger<CheckEligibilityUseCase> logger)
     {
         _checkGateway = checkGateway;
@@ -41,9 +41,9 @@ public class CheckEligibilityUseCase : ICheckEligibilityUseCase
         _logger = logger;
     }
 
-    public async Task<CheckEligibilityResponse> Execute(CheckEligibilityRequest model, CheckEligibilityType routeType)
+    public async Task<CheckEligibilityResponse> Execute<T>(CheckEligibilityRequest<T> model, CheckEligibilityType routeType) where T : IEligibilityServiceType
     {
-        if (model?.Data == null)
+        if (model == null || model.Data == null)
         {
             throw new ValidationException(null, "Missing request data");
         }

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -96,7 +96,7 @@ Cypress.Commands.add('verifyGetEligibilityCheckResponseData', (response, request
   // Calculate total number of elements in data and links
   const totalElements = Object.keys(responseData).length + Object.keys(responseLinks).length;
   // Verfiy total number of elements
-  cy.verifyTotalElements(totalElements, 10);
+  cy.verifyTotalElements(totalElements, 9);
 
   expect(responseData).to.have.property('nationalInsuranceNumber', requestData.data.nationalInsuranceNumber);
   expect(responseData).to.have.property('lastName', requestData.data.lastName);


### PR DESCRIPTION
Endpoint for WF check results
Introducing a new class for WF request data and re-factoring code to accommodate two different request data types.
Adding new table for WorkingFamiliesEvent. 
Business logic for record not found introduced.
Amending tests,  around check process. Assigning FSM type  to all FSM related checks results. 
Introducing new Test for a valid WF check result.

Story : https://dev.azure.com/dfe-gov-uk/Solutions%20Development/_boards/board/t/ECS/Stories?workitem=217200