### PR TITLE
223897 client identifer for each data object being set to major client identifier for batch checks

### DIFF
--- a/CheckYourEligibility.API/Boundary/Requests/CheckEligibilityRequest.cs
+++ b/CheckYourEligibility.API/Boundary/Requests/CheckEligibilityRequest.cs
@@ -119,7 +119,11 @@ public static class EligibilityBulkModelFactory
             if (item.Type != routeType)
                 item.Type = routeType;
 
-            item.ClientIdentifier = model.ClientIdentifier;
+            if (model.ClientIdentifier != null && item.ClientIdentifier == null) {
+
+                item.ClientIdentifier = model.ClientIdentifier;
+            }
+            
         }
         
         return model;

--- a/CheckYourEligibility.API/Boundary/Requests/CheckEligibilityRequest.cs
+++ b/CheckYourEligibility.API/Boundary/Requests/CheckEligibilityRequest.cs
@@ -119,11 +119,7 @@ public static class EligibilityBulkModelFactory
             if (item.Type != routeType)
                 item.Type = routeType;
 
-            if (model.ClientIdentifier != null && item.ClientIdentifier == null) {
-
-                item.ClientIdentifier = model.ClientIdentifier;
-            }
-            
+                          
         }
         
         return model;


### PR DESCRIPTION
Remove logic where all items CID gets set to batch CID . This is not an expected behaviour.