### PR TITLE
215298 streamline error messages

### DIFF
--- a/CheckYourEligibility.API/Boundary/Responses/ErrorResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/ErrorResponse.cs
@@ -7,7 +7,7 @@ public class ErrorResponse
 
 public class Error
 {
-    public string Status { get; set; }
+    public int Status { get; set; }
     public string Title { get; set; }
     public string? Detail { get; set; }
 }

--- a/CheckYourEligibility.API/Controllers/EligibilityController.cs
+++ b/CheckYourEligibility.API/Controllers/EligibilityController.cs
@@ -376,7 +376,7 @@ public class EligibilityCheckController : BaseController
         }
         catch (NotFoundException)
         {
-            return NotFound(new ErrorResponse { Errors = [new Error { Title = guid, Status = "404" }] });
+            return NotFound(new ErrorResponse { Errors = [new Error { Title = guid, Status = StatusCodes.Status404NotFound }] });
         }
 
         catch (ValidationException ex)

--- a/CheckYourEligibility.API/Usecases/CheckEligibilityBulkUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CheckEligibilityBulkUseCase.cs
@@ -70,20 +70,19 @@ public class CheckEligibilityBulkUseCase : ICheckEligibilityBulkUseCase
             var result = _validator.Validate(item);
             if (!result.IsValid)
             {
-                string title = string.Empty;
                 for(int i = 0; i < result.Errors.Count; i++ )
                 {
-                     title = string.Join(Environment.NewLine, result.Errors);
+                    Error error = new Error
+                    {
+
+                        Status = StatusCodes.Status400BadRequest,
+                        Title = result.Errors[i].ToString(),
+                        Detail = item.ClientIdentifier
+
+                    };
+                    errors.Add(error);
                 }
-                Error error = new Error
-                {
-
-                    Status = StatusCodes.Status400BadRequest,
-                    Title = title,
-                    Detail = item.ClientIdentifier
-
-                };
-                errors.Add(error);
+                
             }
 
             index++;

--- a/CheckYourEligibility.API/Usecases/CheckEligibilityBulkUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CheckEligibilityBulkUseCase.cs
@@ -4,7 +4,6 @@ using CheckYourEligibility.API.Domain.Constants;
 using CheckYourEligibility.API.Domain.Enums;
 using CheckYourEligibility.API.Gateways.Interfaces;
 using FluentValidation;
-using System.Text;
 using ValidationException = CheckYourEligibility.API.Domain.Exceptions.ValidationException;
 
 namespace CheckYourEligibility.API.UseCases;
@@ -56,7 +55,8 @@ public class CheckEligibilityBulkUseCase : ICheckEligibilityBulkUseCase
             throw new ValidationException(null, errorMessage);
         }
 
-        var errors = new StringBuilder();
+        List<Error> errors = new List<Error>();
+
         int index = 1;
 
         foreach (var item in bulkData)
@@ -70,14 +70,27 @@ public class CheckEligibilityBulkUseCase : ICheckEligibilityBulkUseCase
             var result = _validator.Validate(item);
             if (!result.IsValid)
             {
-                errors.AppendLine($"Item {index}: {result}");
+                string title = string.Empty;
+                for(int i = 0; i < result.Errors.Count; i++ )
+                {
+                     title = string.Join(Environment.NewLine, result.Errors);
+                }
+                Error error = new Error
+                {
+
+                    Status = StatusCodes.Status400BadRequest,
+                    Title = title,
+                    Detail = item.ClientIdentifier
+
+                };
+                errors.Add(error);
             }
 
             index++;
         }
 
-        if (errors.Length > 0)
-            throw new ValidationException(null, errors.ToString());
+        if (errors.Count > 0)
+            throw new ValidationException(errors, string.Empty);
 
         var groupId = Guid.NewGuid().ToString();
         await _checkGateway.PostCheck(bulkData, groupId);

--- a/tests/cypress/API/03 - Eligibility/PostEligibilityBulkCheck.cy.ts
+++ b/tests/cypress/API/03 - Eligibility/PostEligibilityBulkCheck.cy.ts
@@ -33,7 +33,7 @@ describe('Post Eligibility Bulk Check - Invalid Requests', () => {
     getandVerifyBearerToken('/oauth2/token', validLoginRequestBody).then((token) => {
       cy.apiRequest('POST', 'bulk-check/working-families', invalidEligiblityCodeBulkRequest, token).then((response) => {
         cy.verifyApiResponseCode(response, 400)
-        expect(response.body.errors[0]).to.have.property('title', 'Item 2: Eligibility code must be 11 digits long\r\n');
+        expect(response.body.errors[0]).to.have.property('title', 'Eligibility code must be 11 digits long');
       });
     });
   });
@@ -42,7 +42,7 @@ describe('Post Eligibility Bulk Check - Invalid Requests', () => {
     getandVerifyBearerToken('/oauth2/token', validLoginRequestBody).then((token) => {
       cy.apiRequest('POST', 'bulk-check/working-families', invalidNinoBulkRequest, token).then((response) => {
         cy.verifyApiResponseCode(response, 400)
-        expect(response.body.errors[0]).to.have.property('title', 'Item 1: Invalid National Insurance Number\r\n');
+        expect(response.body.errors[0]).to.have.property('title', 'Invalid National Insurance Number');
       });
     });
   });
@@ -51,7 +51,7 @@ describe('Post Eligibility Bulk Check - Invalid Requests', () => {
     getandVerifyBearerToken('/oauth2/token', validLoginRequestBody).then((token) => {
       cy.apiRequest('POST', 'bulk-check/working-families', invalidDobBulkRequest, token).then((response) => {
         cy.verifyApiResponseCode(response, 400)
-        expect(response.body.errors[0]).to.have.property('title', 'Item 2: Date of birth is required:- (yyyy-mm-dd)\r\n');
+        expect(response.body.errors[0]).to.have.property('title', 'Date of birth is required:- (yyyy-mm-dd)');
       });
     });
   });
@@ -60,7 +60,7 @@ describe('Post Eligibility Bulk Check - Invalid Requests', () => {
     getandVerifyBearerToken('/oauth2/token', validLoginRequestBody).then((token) => {
       cy.apiRequest('POST', 'bulk-check/working-families', invalidLastNameBulkRequest, token).then((response) => {
         cy.verifyApiResponseCode(response, 400)
-        expect(response.body.errors[0]).to.have.property('title', 'Item 2: LastName is required\r\n');
+        expect(response.body.errors[0]).to.have.property('title', 'LastName is required');
       });
     });
   });
@@ -69,8 +69,8 @@ describe('Post Eligibility Bulk Check - Invalid Requests', () => {
     getandVerifyBearerToken('/oauth2/token', validLoginRequestBody).then((token) => {
       cy.apiRequest('POST', 'bulk-check/working-families', invalidMultiCheckBulkRequest, token).then((response) => {
         cy.verifyApiResponseCode(response, 400)
-        expect(response.body.errors[0]).to.have.property('title', 
-            'Item 1: LastName is required\r\nItem 2: Eligibility code must be 11 digits long\r\n');
+        expect(response.body.errors[0]).to.have.property('title', 'LastName is required');
+        expect(response.body.errors[1]).to.have.property('title', 'Eligibility code must be 11 digits long');
       });
     });
   });


### PR DESCRIPTION
New error response implemented to return list of errors. Each error includes detail = client Identifier  , status - for validation that is set to 400 code, title - error description.
Changed cypher tests around wf bulks checks to accommodate new error structure.

**Changed property status from string to int. Please advise if needs to be changed back ,  I just thought it is a field for the status code.**

Ticket : https://dev.azure.com/dfe-gov-uk/Solutions%20Development/_boards/board/t/ECS/Stories?workitem=215298