### PR TITLE
214201 implement rate limiting for api

### DIFF
--- a/CheckYourEligibility.API.Tests/Gateways/RateLimiterGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/RateLimiterGatewayTests.cs
@@ -1,0 +1,79 @@
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoMapper;
+using CheckYourEligibility.API.Boundary.Requests;
+using CheckYourEligibility.API.Data.Mappings;
+using CheckYourEligibility.API.Domain;
+using CheckYourEligibility.API.Gateways;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace CheckYourEligibility.API.Tests;
+
+public class RateLimiterServiceTests : TestBase.TestBase
+{
+    private IEligibilityCheckContext _fakeInMemoryDb;
+    private RateLimitGateway _sut;
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<EligibilityCheckContext>()
+            .UseInMemoryDatabase("FakeInMemoryDb")
+            .Options;
+
+        _fakeInMemoryDb = new EligibilityCheckContext(options);
+
+        _sut = new RateLimitGateway(new NullLoggerFactory(), _fakeInMemoryDb);
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+    }
+
+    [Test]
+    public async Task Given_Create_Should_Return_Pass()
+    {
+        // Arrange
+        var request = _fixture.Create<RateLimitEvent>();
+        // Act
+        await _sut.Create(request);
+        // Assert
+        Assert.Pass();
+    }
+
+    [Test]
+    public async Task Given_Existing_Event_Update_Return_Pass()
+    {
+        /*
+        // Arrange
+        var request = _fixture.Create<RateLimitEvent>();
+        // Act
+        await _sut.UpdateStatus(request.RateLimitEventId, true);
+        // Assert
+        Assert.Pass();
+        */
+    }
+
+    [Test]
+    public async Task Given_NonExisting_Event_Update_Throws_Exception()
+    {
+        //TODO: Implement test logic
+    }
+
+    [Test]
+    public async Task Given_No_Existing_Event_Get_Query_Size_Is_Zero()
+    {
+        //TODO: Implement test logic
+    }
+
+    [Test]
+    public async Task Given_No_Existing_Event_Get_Query_Size_Returns_Sum()
+    {
+        //TODO: Implement test logic
+    }
+}

--- a/CheckYourEligibility.API.Tests/Gateways/RateLimiterGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/RateLimiterGatewayTests.cs
@@ -76,8 +76,8 @@ public class RateLimiterServiceTests : TestBase.TestBase
 
         // Assert
         response.Should().Be(Task.CompletedTask);
-        //TODO: Assert no databaseoperations were performed
-        
+        _fakeInMemoryDb.RateLimitEvents.Find(guid).Should().BeNull();
+
     }
 
     [Test]

--- a/CheckYourEligibility.API.Tests/Usecases/RateLimitUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/RateLimitUseCaseTests.cs
@@ -60,6 +60,8 @@ public class RateLimitUseCaseTests
 
         // Assert
         result.Should().Be(true);
+        context.Response.StatusCode.Should().NotBe(StatusCodes.Status429TooManyRequests);
+
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
         _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
         _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Once);
@@ -89,6 +91,8 @@ public class RateLimitUseCaseTests
 
         // Assert
         result.Should().Be(false);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests);
+
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
         _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
         _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Never);
@@ -119,6 +123,8 @@ public class RateLimitUseCaseTests
 
         // Assert
         result.Should().Be(true);
+        context.Response.StatusCode.Should().NotBe(StatusCodes.Status429TooManyRequests);
+
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
         _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
         _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Once);
@@ -151,6 +157,8 @@ public class RateLimitUseCaseTests
 
         // Assert
         result.Should().Be(false);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests);
+
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
         _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
         _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Never);
@@ -176,6 +184,8 @@ public class RateLimitUseCaseTests
 
         // Assert
         result.Should().Be(true);
+        context.Response.StatusCode.Should().NotBe(StatusCodes.Status429TooManyRequests);
+        
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Never);
         _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Never);
         _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Never);

--- a/CheckYourEligibility.API.Tests/Usecases/RateLimitUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/RateLimitUseCaseTests.cs
@@ -6,6 +6,7 @@ using CheckYourEligibility.API.Gateways.Interfaces;
 using CheckYourEligibility.API.UseCases;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace CheckYourEligibility.API.Tests.UseCases;
@@ -15,6 +16,7 @@ public class RateLimitUseCaseTests
 {
     private Mock<IRateLimit> _mockRateLimitGateway = null!;
     private Mock<IHttpContextAccessor> _mockHttpContextAccessor = null!;
+    private Mock<ILogger<CreateRateLimitEventUseCase>> _mockLogger = null!;
     private CreateRateLimitEventUseCase _sut = null!;
     private Fixture _fixture = null!;
 
@@ -24,7 +26,8 @@ public class RateLimitUseCaseTests
     {
         _mockRateLimitGateway = new Mock<IRateLimit>(MockBehavior.Strict);
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>(MockBehavior.Strict);
-        _sut = new CreateRateLimitEventUseCase(_mockRateLimitGateway.Object, _mockHttpContextAccessor.Object);
+        _mockLogger = new Mock<ILogger<CreateRateLimitEventUseCase>>(MockBehavior.Loose);
+        _sut = new CreateRateLimitEventUseCase(_mockRateLimitGateway.Object, _mockHttpContextAccessor.Object, _mockLogger.Object);
         _fixture = new Fixture();
     }
 
@@ -62,7 +65,8 @@ public class RateLimitUseCaseTests
         context.Response.StatusCode.Should().NotBe(StatusCodes.Status429TooManyRequests);
 
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
-        _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
+        _mockRateLimitGateway.Verify(
+            s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
         _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Never);
     }
 
@@ -94,7 +98,8 @@ public class RateLimitUseCaseTests
         context.Response.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests);
 
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
-        _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
+        _mockRateLimitGateway.Verify(
+            s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
         _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), false), Times.Once);
     }
 
@@ -125,7 +130,8 @@ public class RateLimitUseCaseTests
         context.Response.StatusCode.Should().NotBe(StatusCodes.Status429TooManyRequests);
 
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
-        _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
+        _mockRateLimitGateway.Verify(
+            s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
         _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Never);
     }
 
@@ -160,7 +166,8 @@ public class RateLimitUseCaseTests
         context.Response.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests);
 
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
-        _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
+        _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(
+            It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
         _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), false), Times.Once);
     }
 
@@ -187,7 +194,8 @@ public class RateLimitUseCaseTests
         context.Response.StatusCode.Should().NotBe(StatusCodes.Status429TooManyRequests);
         
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Never);
-        _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Never);
+        _mockRateLimitGateway.Verify(
+            s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Never);
         _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Never);
     }
 }

--- a/CheckYourEligibility.API.Tests/Usecases/RateLimitUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/RateLimitUseCaseTests.cs
@@ -1,0 +1,54 @@
+using AutoFixture;
+using CheckYourEligibility.API.Boundary.Requests;
+using CheckYourEligibility.API.Boundary.Responses;
+using CheckYourEligibility.API.Domain;
+using CheckYourEligibility.API.Domain.Enums;
+using CheckYourEligibility.API.Gateways.Interfaces;
+using CheckYourEligibility.API.UseCases;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using NUnit.Framework.Constraints;
+
+namespace CheckYourEligibility.API.Tests.UseCases;
+
+[TestFixture]
+public class RateLimitUseCaseTests
+{
+    private Mock<IRateLimit> _mockRateLimitGateway = null!;
+    private CreateRateLimitEventUseCase _sut = null!;
+    private Fixture _fixture = null!;
+
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockRateLimitGateway = new Mock<IRateLimit>(MockBehavior.Strict);
+        _sut = new CreateRateLimitEventUseCase(_mockRateLimitGateway.Object);
+        _fixture = new Fixture();
+    }
+
+    [Test]
+    public async Task Execute_Should_Allow_Request_When_Size_LessThan_Capacity()
+    {
+        /*
+        // Arrange
+        var httpContext = _fixture.Create<HttpContext>();
+        var options = _fixture.Create<RateLimiterMiddlewareOptions>();
+
+        _mockRateLimitGateway.Setup(s => s.Create(It.IsAny<RateLimitEvent>())).Returns(Task.CompletedTask);
+        _mockRateLimitGateway.Setup(s => s.UpdateStatus(It.IsAny<string>(), true)).Returns(Task.CompletedTask);
+        _mockRateLimitGateway.Setup(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength))
+            .Returns(Task.FromResult(1));
+
+        // Act
+        var result = await _sut.Execute(httpContext, options);
+
+        // Assert
+        result.Should().Be(true);
+        _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
+        _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
+        _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Once);
+        */
+    }
+}

--- a/CheckYourEligibility.API.Tests/Usecases/RateLimitUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/RateLimitUseCaseTests.cs
@@ -43,7 +43,6 @@ public class RateLimitUseCaseTests
         options.PermitLimit = 10;
 
         _mockRateLimitGateway.Setup(s => s.Create(It.IsAny<RateLimitEvent>())).Returns(Task.CompletedTask);
-        _mockRateLimitGateway.Setup(s => s.UpdateStatus(It.IsAny<string>(), true)).Returns(Task.CompletedTask);
         _mockRateLimitGateway.Setup(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength))
             .Returns(Task.FromResult(1));
 
@@ -64,7 +63,7 @@ public class RateLimitUseCaseTests
 
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
         _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
-        _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Once);
+        _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Never);
     }
 
     [Test]
@@ -75,6 +74,7 @@ public class RateLimitUseCaseTests
         options.PermitLimit = 1;
 
         _mockRateLimitGateway.Setup(s => s.Create(It.IsAny<RateLimitEvent>())).Returns(Task.CompletedTask);
+        _mockRateLimitGateway.Setup(s => s.UpdateStatus(It.IsAny<string>(), false)).Returns(Task.CompletedTask);
         _mockRateLimitGateway.Setup(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength))
             .Returns(Task.FromResult(1));
 
@@ -95,7 +95,7 @@ public class RateLimitUseCaseTests
 
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
         _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
-        _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Never);
+        _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), false), Times.Once);
     }
 
     [Test]
@@ -106,7 +106,6 @@ public class RateLimitUseCaseTests
         options.PermitLimit = 1;
 
         _mockRateLimitGateway.Setup(s => s.Create(It.IsAny<RateLimitEvent>())).Returns(Task.CompletedTask);
-        _mockRateLimitGateway.Setup(s => s.UpdateStatus(It.IsAny<string>(), true)).Returns(Task.CompletedTask);
         _mockRateLimitGateway.Setup(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength))
             .Returns(Task.FromResult(0));
 
@@ -127,7 +126,7 @@ public class RateLimitUseCaseTests
 
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
         _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
-        _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Once);
+        _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Never);
     }
 
     [Test]
@@ -138,6 +137,7 @@ public class RateLimitUseCaseTests
         options.PermitLimit = 5;
 
         _mockRateLimitGateway.Setup(s => s.Create(It.IsAny<RateLimitEvent>())).Returns(Task.CompletedTask);
+        _mockRateLimitGateway.Setup(s => s.UpdateStatus(It.IsAny<string>(), false)).Returns(Task.CompletedTask);
         _mockRateLimitGateway.Setup(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength))
             .Returns(Task.FromResult(1));
 
@@ -161,7 +161,7 @@ public class RateLimitUseCaseTests
 
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
         _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
-        _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Never);
+        _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), false), Times.Once);
     }
 
     [Test]

--- a/CheckYourEligibility.API.Tests/Usecases/RateLimitUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/RateLimitUseCaseTests.cs
@@ -1,12 +1,15 @@
+using System.Security.Claims;
 using AutoFixture;
 using CheckYourEligibility.API.Boundary.Requests;
 using CheckYourEligibility.API.Boundary.Responses;
 using CheckYourEligibility.API.Domain;
 using CheckYourEligibility.API.Domain.Enums;
+using CheckYourEligibility.API.Extensions;
 using CheckYourEligibility.API.Gateways.Interfaces;
 using CheckYourEligibility.API.UseCases;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.OpenApi.Writers;
 using Moq;
 using NUnit.Framework.Constraints;
 
@@ -16,6 +19,7 @@ namespace CheckYourEligibility.API.Tests.UseCases;
 public class RateLimitUseCaseTests
 {
     private Mock<IRateLimit> _mockRateLimitGateway = null!;
+    private Mock<IHttpContextAccessor> _mockHttpContextAccessor = null!;
     private CreateRateLimitEventUseCase _sut = null!;
     private Fixture _fixture = null!;
 
@@ -24,16 +28,15 @@ public class RateLimitUseCaseTests
     public void Setup()
     {
         _mockRateLimitGateway = new Mock<IRateLimit>(MockBehavior.Strict);
-        _sut = new CreateRateLimitEventUseCase(_mockRateLimitGateway.Object);
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>(MockBehavior.Strict);
+        _sut = new CreateRateLimitEventUseCase(_mockRateLimitGateway.Object, _mockHttpContextAccessor.Object);
         _fixture = new Fixture();
     }
 
     [Test]
     public async Task Execute_Should_Allow_Request_When_Size_LessThan_Capacity()
     {
-        /*
         // Arrange
-        var httpContext = _fixture.Create<HttpContext>();
         var options = _fixture.Create<RateLimiterMiddlewareOptions>();
 
         _mockRateLimitGateway.Setup(s => s.Create(It.IsAny<RateLimitEvent>())).Returns(Task.CompletedTask);
@@ -41,14 +44,21 @@ public class RateLimitUseCaseTests
         _mockRateLimitGateway.Setup(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength))
             .Returns(Task.FromResult(1));
 
+        var context = new DefaultHttpContext();
+        var claims = new List<Claim>
+        {
+            new Claim("scope", "local_authority:894")
+        };
+        context.User.AddIdentity(new ClaimsIdentity(claims));
+        _mockHttpContextAccessor.Setup(s => s.HttpContext).Returns(context);
+
         // Act
-        var result = await _sut.Execute(httpContext, options);
+        var result = await _sut.Execute(options);
 
         // Assert
         result.Should().Be(true);
         _mockRateLimitGateway.Verify(s => s.Create(It.IsAny<RateLimitEvent>()), Times.Once);
         _mockRateLimitGateway.Verify(s => s.GetQueriesInWindow(It.IsAny<string>(), It.IsAny<DateTime>(), options.WindowLength), Times.Once);
         _mockRateLimitGateway.Verify(s => s.UpdateStatus(It.IsAny<string>(), true), Times.Once);
-        */
     }
 }

--- a/CheckYourEligibility.API/Domain/RateLimitEvent.cs
+++ b/CheckYourEligibility.API/Domain/RateLimitEvent.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CheckYourEligibility.API.Domain;
+
+[ExcludeFromCodeCoverage(Justification = "Data Model.")]
+public class RateLimitEvent
+{
+    [Key] public string RateLimitEventId { get; set; }
+    public DateTime TimeStamp { get; set; }
+
+    [Column(TypeName = "varchar(100)")] public string PartitionName { get; set; }
+
+    public int QuerySize { get; set; }
+
+    [Column(TypeName = "boolean")] public bool Accepted { get; set; }
+}

--- a/CheckYourEligibility.API/Domain/RateLimitEvent.cs
+++ b/CheckYourEligibility.API/Domain/RateLimitEvent.cs
@@ -14,5 +14,5 @@ public class RateLimitEvent
 
     public int QuerySize { get; set; }
 
-    [Column(TypeName = "boolean")] public bool Accepted { get; set; }
+    public bool Accepted { get; set; }
 }

--- a/CheckYourEligibility.API/Domain/Validation/RateLimiter.cs
+++ b/CheckYourEligibility.API/Domain/Validation/RateLimiter.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Nodes;
-using CheckYourEligibility.API.Extensions;
 using CheckYourEligibility.API.UseCases;
 
 public class RateLimiterMiddlewareOptions
@@ -21,7 +19,7 @@ public class RateLimiter
     }
     public async Task InvokeAsync(HttpContext httpContext, ICreateRateLimitEventUseCase rateLimitUseCase)
     {
-        if (await rateLimitUseCase.Execute(httpContext, _options))
+        if (await rateLimitUseCase.Execute(_options))
         {
             await _next(httpContext);
         }

--- a/CheckYourEligibility.API/Domain/Validation/RateLimiter.cs
+++ b/CheckYourEligibility.API/Domain/Validation/RateLimiter.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using CheckYourEligibility.API.Domain;
+using NetTopologySuite.GeometriesGraph;
+using Newtonsoft.Json;
+
+public class RateLimiter
+{
+    private readonly RequestDelegate _next;
+    private readonly IEligibilityCheckContext _db;
+    //private readonly IHttpContextAccessor _httpContextAccessor;
+    private TimeSpan _windowLength;
+    private int _permitLimit;
+
+    public RateLimiter(RequestDelegate next,
+        TimeSpan windowLength,
+        int permitLimit
+        )
+    {
+        _next = next;
+        _windowLength = windowLength;
+        _permitLimit = permitLimit;
+    }
+
+    private int getCapacity(string partition, DateTime requestTimeStamp)
+    {
+        int checksInWindow = 0;  //db.RateLimitEvents
+            //.Where(x => x.PartitionName == partition && x.TimeStamp >= requestTimeStamp.Subtract(_windowLength))
+            //.Sum(x => x.QuerySize);
+        return _permitLimit - checksInWindow;
+    }
+
+    private string getPartition(HttpContext httpContext)
+    {
+        var headers = httpContext.Request.Headers; //TODO: Or is this contained within the scope body?
+        int authorityId = 0; //TODO Get authority id from scope in headers
+        return $"authority-id-policy-{authorityId}";
+        //TODO: The policy name should be parameterised. Otherwise the query is stored n times, 
+        // where n is the number of policies that are active e.g. 2 times if we have 2 policies for different time periods
+        // Alternatively we would have to be able to chain the policies together, and only write to db once across all policies
+    }
+
+    private async Task<int> getQuerySize(HttpContext httpContext)
+    {
+        //TODO: Rework with better error/null handling
+        if (httpContext.Request.Path.ToString().Contains("bulk-check"))
+        {
+            httpContext.Request.EnableBuffering();
+            var body = await System.Text.Json.JsonSerializer.DeserializeAsync<JsonObject>(httpContext.Request.Body);
+            httpContext.Request.Body.Position = 0;
+            JsonNode data;
+            if (body.TryGetPropertyValue("data", out data))
+            {
+                return data.AsArray().Count;
+            }
+        }
+        return 1;
+    }
+
+    public async Task InvokeAsync(HttpContext httpContext, IEligibilityCheckContext db)
+    {
+        string partition = getPartition(httpContext);
+        int querySize = await getQuerySize(httpContext);
+        //Firstly record the event
+        RateLimitEvent rlEvent = new RateLimitEvent
+        {
+            RateLimitEventId = Guid.NewGuid().ToString(),
+            PartitionName = partition,
+            TimeStamp = DateTime.UtcNow, //TODO: Maybe take from when the http request was received?
+            QuerySize = querySize,
+            Accepted = false //TODO: Use a different status when we're yet to determine if it's permitted
+        };
+        //var checksInWindow = db.RateLimitEvents.Where(x => x.PartitionName == partition).Sum(x => x.QuerySize);
+        //await db.RateLimitEvents.AddAsync(rlEvent);
+        //await db.SaveChangesAsync();
+        await _next(httpContext);
+
+        /*
+                //var checksInWindow = db.RateLimitEvents
+                //    .Where(x => x.PartitionName == partition && x.TimeStamp >= rlEvent.TimeStamp.Subtract(_windowLength));
+                //.Sum(x => x.QuerySize);
+
+                //Then determine whether the event was viable
+                if (querySize > getCapacity(partition, rlEvent.TimeStamp))
+                //if (querySize > _permitLimit - checksInWindow)
+                {
+                    rlEvent.Accepted = false;
+                    //await _db.SaveChangesAsync();
+                    //TODO: Maybe log the rejection
+                    //TODO: Set a 429 response and queryRetryTime
+                    httpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                    return;
+                }
+                else
+                {
+                    rlEvent.Accepted = true;
+                    //await _db.SaveChangesAsync();
+                    await _next(httpContext);
+                }
+                */
+    }
+}
+
+public static class RateLimiterExtensions
+{
+    public static IApplicationBuilder UseCustomRateLimiter(
+        this IApplicationBuilder builder, TimeSpan windowSize, int permitLimit)
+    {
+        return builder.UseMiddleware<RateLimiter>(windowSize, permitLimit);
+    }
+}

--- a/CheckYourEligibility.API/Gateways/Interfaces/IRateLimit.cs
+++ b/CheckYourEligibility.API/Gateways/Interfaces/IRateLimit.cs
@@ -5,4 +5,6 @@ namespace CheckYourEligibility.API.Gateways.Interfaces;
 public interface IRateLimit
 {
     Task Create(RateLimitEvent item);
+    Task UpdateStatus(string guid, bool accepted);
+    Task<int> GetQueriesInWindow(string partition, DateTime eventTimeStamp, TimeSpan windowLength);
 }

--- a/CheckYourEligibility.API/Gateways/Interfaces/IRateLimit.cs
+++ b/CheckYourEligibility.API/Gateways/Interfaces/IRateLimit.cs
@@ -1,0 +1,8 @@
+using CheckYourEligibility.API.Domain;
+
+namespace CheckYourEligibility.API.Gateways.Interfaces;
+
+public interface IRateLimit
+{
+    Task Create(RateLimitEvent item);
+}

--- a/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
+++ b/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
@@ -22,11 +22,8 @@ public class RateLimitGateway : BaseGateway, IRateLimit
     /// <returns></returns>
     public async Task Create(RateLimitEvent item)
     {
-        //TODO: Should this be async??
-        //TODO: What if event already exists?
-        await _db.RateLimitEvents.AddAsync(item);
+        _db.RateLimitEvents.Add(item);
         await _db.SaveChangesAsync();
-        return;
     }
     
     /// <summary>
@@ -38,11 +35,12 @@ public class RateLimitGateway : BaseGateway, IRateLimit
     public async Task UpdateStatus(string guid, bool accepted)
     {
         var rateLimitEvent = _db.RateLimitEvents.Find(guid);
-        //TODO: Null handling
-        rateLimitEvent.Accepted = accepted;
-        _db.RateLimitEvents.Update(rateLimitEvent);
-        _db.SaveChanges();
-        return;
+        if (rateLimitEvent != null)
+        {
+            rateLimitEvent.Accepted = accepted;
+            _db.RateLimitEvents.Update(rateLimitEvent);
+            _db.SaveChanges();
+        }
     }
 
     /// <summary>

--- a/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
+++ b/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
@@ -26,4 +26,34 @@ public class RateLimitGateway : BaseGateway, IRateLimit
         await _db.SaveChangesAsync();
         return;
     }
+    
+    /// <summary>
+    ///     Sets the status of the rateLimitEvent, reflecting the decision made of whether to permit the request
+    /// </summary>
+    /// <param name="guid"></param>
+    /// <param name="accepted"></param>
+    /// <returns></returns>
+    public async Task UpdateStatus(string guid, bool accepted)
+    {
+        var rateLimitEvent = _db.RateLimitEvents.Find(guid);
+        rateLimitEvent.Accepted = accepted;
+        _db.RateLimitEvents.Update(rateLimitEvent);
+        _db.SaveChanges();
+        return;
+    }
+
+    /// <summary>
+    ///     Gets the sum of the number of checks that have been submitted 
+    /// </summary>
+    /// <param name="partition"></param>
+    /// <param name="eventTimeStamp"></param>
+    /// <param name="windowLength"></param>
+    /// <returns></returns>
+    public async Task<int> GetQueriesInWindow(string partition, DateTime eventTimeStamp, TimeSpan windowLength)
+    {
+        return _db.RateLimitEvents.Where(x => x.PartitionName == partition &&
+            x.TimeStamp < eventTimeStamp && 
+            x.TimeStamp >= eventTimeStamp.Subtract(windowLength))
+        .Sum(x => x.QuerySize);
+    }
 }

--- a/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
+++ b/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
@@ -1,0 +1,29 @@
+using CheckYourEligibility.API.Gateways.Interfaces;
+using CheckYourEligibility.API.Domain;
+
+namespace CheckYourEligibility.API.Gateways;
+
+public class RateLimitGateway : BaseGateway, IRateLimit
+{
+    private readonly IEligibilityCheckContext _db;
+
+    private readonly ILogger _logger;
+
+    public RateLimitGateway(ILoggerFactory logger, IEligibilityCheckContext dbContext)
+    {
+        _logger = logger.CreateLogger("RateLimitService");
+        _db = dbContext;
+    }
+
+    /// <summary>
+    ///     Creates a rate limit event
+    /// </summary>
+    /// <param name="item"></param>
+    /// <returns></returns>
+    public async Task Create(RateLimitEvent item)
+    {
+        await _db.RateLimitEvents.AddAsync(item);
+        await _db.SaveChangesAsync();
+        return;
+    }
+}

--- a/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
+++ b/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
@@ -22,6 +22,8 @@ public class RateLimitGateway : BaseGateway, IRateLimit
     /// <returns></returns>
     public async Task Create(RateLimitEvent item)
     {
+        //TODO: Should this be async??
+        //TODO: What if event already exists?
         await _db.RateLimitEvents.AddAsync(item);
         await _db.SaveChangesAsync();
         return;
@@ -36,6 +38,7 @@ public class RateLimitGateway : BaseGateway, IRateLimit
     public async Task UpdateStatus(string guid, bool accepted)
     {
         var rateLimitEvent = _db.RateLimitEvents.Find(guid);
+        //TODO: Null handling
         rateLimitEvent.Accepted = accepted;
         _db.RateLimitEvents.Update(rateLimitEvent);
         _db.SaveChanges();
@@ -54,6 +57,6 @@ public class RateLimitGateway : BaseGateway, IRateLimit
         return _db.RateLimitEvents.Where(x => x.PartitionName == partition &&
             x.TimeStamp < eventTimeStamp && 
             x.TimeStamp >= eventTimeStamp.Subtract(windowLength))
-        .Sum(x => x.QuerySize);
+            .Sum(x => x.QuerySize);
     }
 }

--- a/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
+++ b/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
@@ -96,8 +96,7 @@ public class EligibilityCheckContext : DbContext, IEligibilityCheckContext
         modelBuilder.Entity<EligibilityCheckHash>()
             .HasIndex(b => b.Hash, "idx_EligibilityCheckHash");
 
-        modelBuilder.Entity<RateLimitEvent>() //TODO: Maybe index by timestamp/partition?
-            .HasIndex(b => b.RateLimitEventId, "idx_RateLimitEventId");
+        //TODO: Likely need to index the RateLimitEvents by partitionName and timestamp
 
         modelBuilder.Entity<User>()
             .HasIndex(p => new { p.Email, p.Reference }).IsUnique();

--- a/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
+++ b/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
@@ -96,8 +96,6 @@ public class EligibilityCheckContext : DbContext, IEligibilityCheckContext
         modelBuilder.Entity<EligibilityCheckHash>()
             .HasIndex(b => b.Hash, "idx_EligibilityCheckHash");
 
-        //TODO: Likely need to index the RateLimitEvents by partitionName and timestamp
-
         modelBuilder.Entity<User>()
             .HasIndex(p => new { p.Email, p.Reference }).IsUnique();
     }

--- a/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
+++ b/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
@@ -24,6 +24,7 @@ public class EligibilityCheckContext : DbContext, IEligibilityCheckContext
     public virtual DbSet<Application> Applications { get; set; }
     public virtual DbSet<ApplicationStatus> ApplicationStatuses { get; set; }
     public virtual DbSet<EligibilityCheckHash> EligibilityCheckHashes { get; set; }
+    public virtual DbSet<RateLimitEvent> RateLimitEvents { get; set; }
     public virtual DbSet<User> Users { get; set; }
     public virtual DbSet<Audit> Audits { get; set; }
 
@@ -94,6 +95,9 @@ public class EligibilityCheckContext : DbContext, IEligibilityCheckContext
 
         modelBuilder.Entity<EligibilityCheckHash>()
             .HasIndex(b => b.Hash, "idx_EligibilityCheckHash");
+
+        modelBuilder.Entity<RateLimitEvent>() //TODO: Maybe index by timestamp/partition?
+            .HasIndex(b => b.RateLimitEventId, "idx_RateLimitEventId");
 
         modelBuilder.Entity<User>()
             .HasIndex(p => new { p.Email, p.Reference }).IsUnique();

--- a/CheckYourEligibility.API/Infrastructure/IEligibilityCheckContext.cs
+++ b/CheckYourEligibility.API/Infrastructure/IEligibilityCheckContext.cs
@@ -12,6 +12,7 @@ public interface IEligibilityCheckContext
     DbSet<Application> Applications { get; set; }
     DbSet<ApplicationStatus> ApplicationStatuses { get; set; }
     DbSet<EligibilityCheckHash> EligibilityCheckHashes { get; set; }
+    DbSet<RateLimitEvent> RateLimitEvents { get; set; }
     DbSet<User> Users { get; set; }
     DbSet<Audit> Audits { get; set; }
     void BulkInsert_FreeSchoolMealsHO(IEnumerable<FreeSchoolMealsHO> data);

--- a/CheckYourEligibility.API/Migrations/20250811162210_AddRateLimitEvents.Designer.cs
+++ b/CheckYourEligibility.API/Migrations/20250811162210_AddRateLimitEvents.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CheckYourEligibility.API.Migrations
 {
     [DbContext(typeof(EligibilityCheckContext))]
-    partial class EligibilityCheckContextModelSnapshot : ModelSnapshot
+    [Migration("20250811162210_AddRateLimitEvents")]
+    partial class AddRateLimitEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CheckYourEligibility.API/Migrations/20250811162210_AddRateLimitEvents.cs
+++ b/CheckYourEligibility.API/Migrations/20250811162210_AddRateLimitEvents.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CheckYourEligibility.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRateLimitEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RateLimitEvents",
+                columns: table => new
+                {
+                    RateLimitEventId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    TimeStamp = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    PartitionName = table.Column<string>(type: "varchar(100)", nullable: false),
+                    QuerySize = table.Column<int>(type: "int", nullable: false),
+                    Accepted = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RateLimitEvents", x => x.RateLimitEventId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RateLimitEvents");
+        }
+    }
+}

--- a/CheckYourEligibility.API/Program.cs
+++ b/CheckYourEligibility.API/Program.cs
@@ -178,6 +178,8 @@ builder.Services.AddScoped<ISendNotificationUseCase, SendNotificationUseCase>();
 
 builder.Services.AddScoped<IValidator<IEligibilityServiceType>, CheckEligibilityRequestDataValidator>();
 
+builder.Services.AddScoped<IEligibilityCheckContext, EligibilityCheckContext>();
+
 builder.Services.AddTransient<INotificationClient>(x =>
     new NotificationClient(builder.Configuration.GetValue<string>("Notify:Key")));
 builder.Services.AddTransient<INotificationClient>(x =>
@@ -236,6 +238,15 @@ app.UseSwaggerUI(c =>
 
 // 2.6. Map Controllers
 app.MapControllers();
+
+// 2.7 RateLimiter Middleware
+//app.UseCustomRateLimiter(); //TODO: Move it before the euthentication/authorization?
+//First rate limiter policy
+app.UseWhen(context => context.Request.Path == "/check/working-families"
+|| context.Request.Path == "/bulk-check/working-families", app => app.UseCustomRateLimiter(TimeSpan.FromMinutes(1), 10));
+//Second rate limiter policy
+app.UseWhen(context => context.Request.Path == "/check/working-families", app => app.UseCustomRateLimiter(TimeSpan.FromHours(1), 20));
+//app.MapPost("/check/working-families", RateLimiterExtensions.UseCustomRateLimiter);
 
 app.Run();
 

--- a/CheckYourEligibility.API/Program.cs
+++ b/CheckYourEligibility.API/Program.cs
@@ -175,10 +175,9 @@ builder.Services.AddScoped<IUpdateEligibilityCheckStatusUseCase, UpdateEligibili
 builder.Services.AddScoped<IProcessEligibilityCheckUseCase, ProcessEligibilityCheckUseCase>();
 builder.Services.AddScoped<IGetEligibilityCheckItemUseCase, GetEligibilityCheckItemUseCase>();
 builder.Services.AddScoped<ISendNotificationUseCase, SendNotificationUseCase>();
+builder.Services.AddScoped<ICreateRateLimitEventUseCase, CreateRateLimitEventUseCase>();
 
 builder.Services.AddScoped<IValidator<IEligibilityServiceType>, CheckEligibilityRequestDataValidator>();
-
-builder.Services.AddScoped<IEligibilityCheckContext, EligibilityCheckContext>();
 
 builder.Services.AddTransient<INotificationClient>(x =>
     new NotificationClient(builder.Configuration.GetValue<string>("Notify:Key")));
@@ -243,9 +242,9 @@ app.MapControllers();
 //app.UseCustomRateLimiter(); //TODO: Move it before the euthentication/authorization?
 //First rate limiter policy
 app.UseWhen(context => context.Request.Path == "/check/working-families"
-|| context.Request.Path == "/bulk-check/working-families", app => app.UseCustomRateLimiter(TimeSpan.FromMinutes(1), 10));
+|| context.Request.Path == "/bulk-check/working-families", app => app.UseCustomRateLimiter("Authority-Id-Minute", TimeSpan.FromMinutes(1), 10));
 //Second rate limiter policy
-app.UseWhen(context => context.Request.Path == "/check/working-families", app => app.UseCustomRateLimiter(TimeSpan.FromHours(1), 20));
+app.UseWhen(context => context.Request.Path == "/check/working-families", app => app.UseCustomRateLimiter("Authority-Id-Hour", TimeSpan.FromHours(1), 20));
 //app.MapPost("/check/working-families", RateLimiterExtensions.UseCustomRateLimiter);
 
 app.Run();

--- a/CheckYourEligibility.API/Program.cs
+++ b/CheckYourEligibility.API/Program.cs
@@ -239,13 +239,24 @@ app.UseSwaggerUI(c =>
 app.MapControllers();
 
 // 2.7 RateLimiter Middleware
-//app.UseCustomRateLimiter(); //TODO: Move it before the euthentication/authorization?
+//TODO: Move it before the euthentication/authorization?
+//TODO: Apply to all check endpoints
 //First rate limiter policy
-app.UseWhen(context => context.Request.Path == "/check/working-families"
-|| context.Request.Path == "/bulk-check/working-families", app => app.UseCustomRateLimiter("Authority-Id-Minute", TimeSpan.FromMinutes(1), 10));
+app.UseWhen(context => context.Request.Path == "/check/working-families" || context.Request.Path == "/bulk-check/working-families",
+    app => app.UseCustomRateLimiter(new RateLimiterMiddlewareOptions
+        {
+            PartionName = "Authority-Id-Minute",
+            WindowLength = TimeSpan.FromMinutes(1),
+            PermitLimit = 1
+        }));
 //Second rate limiter policy
-app.UseWhen(context => context.Request.Path == "/check/working-families", app => app.UseCustomRateLimiter("Authority-Id-Hour", TimeSpan.FromHours(1), 20));
-//app.MapPost("/check/working-families", RateLimiterExtensions.UseCustomRateLimiter);
+app.UseWhen(context => context.Request.Path == "/check/working-families",
+    app => app.UseCustomRateLimiter(new RateLimiterMiddlewareOptions
+        {
+            PartionName = "Authority-Id-Hour",
+            WindowLength = TimeSpan.FromHours(1),
+            PermitLimit = 20
+        }));
 
 app.Run();
 

--- a/CheckYourEligibility.API/Program.cs
+++ b/CheckYourEligibility.API/Program.cs
@@ -240,20 +240,20 @@ app.MapControllers();
 
 // 2.7 RateLimiter Middleware
 app.UseWhen(context => context.Request.Method == RequestMethod.Post.ToString() &&
-    context.Request.Path.StartsWithSegments("/check") || context.Request.Path.StartsWithSegments("/bulk-check"),
+    (context.Request.Path.StartsWithSegments("/check") || context.Request.Path.StartsWithSegments("/bulk-check")),
     app => app.UseCustomRateLimiter(
         new RateLimiterMiddlewareOptions
         {
             PartionName = "Authority-Id-Minute",
             WindowLength = TimeSpan.FromMinutes(builder.Configuration.GetValue("RateLimit:Policies:Authority-Id-Minute:WindowLength", 1)),
-            PermitLimit = builder.Configuration.GetValue("RateLimit:Policies:Authority-Id-Minute:PermitLimit", 100)
+            PermitLimit = builder.Configuration.GetValue("RateLimit:Policies:Authority-Id-Minute:PermitLimit", 250)
         })
     .UseCustomRateLimiter(
         new RateLimiterMiddlewareOptions
         {
             PartionName = "Authority-Id-Hour",
             WindowLength = TimeSpan.FromHours(builder.Configuration.GetValue("RateLimit:Policies:Authority-Id-Hour:WindowLength", 1)),
-            PermitLimit = builder.Configuration.GetValue("RateLimit:Policies:Authority-Id-Hour:PermitLimit", 1000)
+            PermitLimit = builder.Configuration.GetValue("RateLimit:Policies:Authority-Id-Hour:PermitLimit", 5000)
         }));
 
 app.Run();

--- a/CheckYourEligibility.API/ProgramExtensions.cs
+++ b/CheckYourEligibility.API/ProgramExtensions.cs
@@ -45,6 +45,7 @@ public static class ProgramExtensions
         services.AddTransient<IUsers, UsersGateway>();
         services.AddTransient<IAudit, AuditGateway>();
         services.AddTransient<IHash, HashGateway>();
+        services.AddTransient<IRateLimit, RateLimitGateway>();
         return services;
     }
 

--- a/CheckYourEligibility.API/Usecases/RateLimitUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/RateLimitUseCase.cs
@@ -33,15 +33,13 @@ public class CreateRateLimitEventUseCase : ICreateRateLimitEventUseCase
     }
     public async Task<bool> Execute(RateLimiterMiddlewareOptions options)
     {
-        var localAuthorityIds = _httpContextAccessor.HttpContext.User.GetLocalAuthorityIds("local_authority");
+        var localAuthorityIds = _httpContextAccessor.HttpContext?.User.GetLocalAuthorityIds("local_authority");
         //Early exit if no LA id
         if (localAuthorityIds.IsNullOrEmpty() || localAuthorityIds.SequenceEqual([0]))
         {
-            //TODO: Determine if there's any value in still writing these events to the db
-            //TODO: Determine if null/empty should be handled differently as it signifies an attempt without the correct scope
             return true;
         }
-        string partition = $"{options.PartionName}-{localAuthorityIds[0]}"; //Currently just takes the first value, can there be multiple?
+        string partition = $"{options.PartionName}-{localAuthorityIds[0]}"; //TODO: Currently just takes the first value, can there be multiple?
         
         int querySize = await getQuerySize(_httpContextAccessor.HttpContext);
 
@@ -49,7 +47,7 @@ public class CreateRateLimitEventUseCase : ICreateRateLimitEventUseCase
         {
             RateLimitEventId = Guid.NewGuid().ToString(),
             PartitionName = partition,
-            TimeStamp = DateTime.UtcNow, //TODO: Maybe take from when the http request was received?
+            TimeStamp = DateTime.UtcNow,
             QuerySize = querySize,
             Accepted = false //TODO: Use a different status when we're yet to determine if it's permitted
         };
@@ -61,11 +59,9 @@ public class CreateRateLimitEventUseCase : ICreateRateLimitEventUseCase
             _httpContextAccessor.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
             _httpContextAccessor.HttpContext.Response.Headers.Append("Retry-After", options.WindowLength.TotalSeconds.ToString());
             return false;
-            //TODO: Optional determine retry period based on a db query
         }
         else
         {
-            // Update the status to accepted
             await _rateLimitGateway.UpdateStatus(rlEvent.RateLimitEventId, true);
             return true;
         }
@@ -73,7 +69,6 @@ public class CreateRateLimitEventUseCase : ICreateRateLimitEventUseCase
 
     private async Task<int> getQuerySize(HttpContext httpContext)
     {
-        //TODO: Rework with better error/null handling
         if (httpContext.Request.Path.ToString().Contains("bulk-check"))
         {
             httpContext.Request.EnableBuffering();

--- a/CheckYourEligibility.API/Usecases/RateLimitUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/RateLimitUseCase.cs
@@ -1,24 +1,26 @@
-using CheckYourEligibility.API.Boundary.Requests;
-using CheckYourEligibility.API.Boundary.Responses;
-using CheckYourEligibility.API.Domain.Enums;
+using CheckYourEligibility.API.Domain;
 using CheckYourEligibility.API.Gateways.Interfaces;
+using System.Text.Json.Nodes;
+using System.Threading.RateLimiting;
 
 namespace CheckYourEligibility.API.UseCases;
 
 /// <summary>
 ///     Interface for creating or updating a user.
 /// </summary>
-public interface ICreateRateLimitEvent
+public interface ICreateRateLimitEventUseCase
 {
     /// <summary>
     ///     Execute the use case.
     /// </summary>
-    /// <param name="model"></param>
+    /// <param name="item"></param>
     /// <returns></returns>
-    Task<> Execute(RateLimitEvent item);
+    Task Execute(HttpContext httpContext, RateLimiterMiddlewareOptions options);
+    //Task Execute(RateLimitEvent item);
+
 }
 
-public class CreateRateLimitEventUseCase : ICreateRateLimitEvent
+public class CreateRateLimitEventUseCase : ICreateRateLimitEventUseCase
 {
     private readonly IRateLimit _rateLimitGateway;
 
@@ -27,9 +29,69 @@ public class CreateRateLimitEventUseCase : ICreateRateLimitEvent
         _rateLimitGateway = rateLimitGateway;
     }
 
-    public async Task<> Execute(RateLimitEvent item)
+    /*
+        public async Task Execute(RateLimitEvent item)
+        {
+            await _rateLimitGateway.Create(item);
+            return;
+        }
+        */
+
+    //TODO: Create a RateLimiterOptions class and pass through to this method
+    public async Task Execute(HttpContext httpContext, RateLimiterMiddlewareOptions options)
     {
-        await _rateLimitGateway.Create(item);
+        string partition = getPartition(options.PartionName, httpContext);
+        int querySize = await getQuerySize(httpContext);
+
+        RateLimitEvent rlEvent = new RateLimitEvent
+        {
+            RateLimitEventId = Guid.NewGuid().ToString(),
+            PartitionName = partition,
+            TimeStamp = DateTime.UtcNow, //TODO: Maybe take from when the http request was received?
+            QuerySize = querySize,
+            Accepted = false //TODO: Use a different status when we're yet to determine if it's permitted
+        };
+
+        await _rateLimitGateway.Create(rlEvent);
+        //TODO create an options class and pass into this query
+        int currentRate = await _rateLimitGateway.GetQueriesInWindow(partition, rlEvent.TimeStamp, options.WindowLength);
+        if (querySize > options.PermitLimit - currentRate)
+        {
+            httpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+            return;
+            //TODO: Determine retry period
+        }
+        else
+        {
+            //TODO: Set the status to accepted
+        }
         return;
+    }
+
+    private string getPartition(string partitionName, HttpContext httpContext)
+    {
+        var headers = httpContext.Request.Headers; //TODO: Or is this contained within the scope body?
+        int authorityId = 0; //TODO Get authority id from scope in headers
+        return $"{partitionName}-{authorityId}";
+        // If we share partition names for policies that are could be chained e.g. apply several window/limit combos per endpoint,
+        // Then we would need a mechanism to make sure we only write to db at the end of the chain. Also makes it hard to determine 
+        // the retry period accurately as a combination.
+    }
+
+    private async Task<int> getQuerySize(HttpContext httpContext)
+    {
+        //TODO: Rework with better error/null handling
+        if (httpContext.Request.Path.ToString().Contains("bulk-check"))
+        {
+            httpContext.Request.EnableBuffering();
+            var body = await System.Text.Json.JsonSerializer.DeserializeAsync<JsonObject>(httpContext.Request.Body);
+            httpContext.Request.Body.Position = 0;
+            JsonNode data;
+            if (body.TryGetPropertyValue("data", out data))
+            {
+                return data.AsArray().Count;
+            }
+        }
+        return 1;
     }
 }

--- a/CheckYourEligibility.API/Usecases/RateLimitUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/RateLimitUseCase.cs
@@ -1,0 +1,35 @@
+using CheckYourEligibility.API.Boundary.Requests;
+using CheckYourEligibility.API.Boundary.Responses;
+using CheckYourEligibility.API.Domain.Enums;
+using CheckYourEligibility.API.Gateways.Interfaces;
+
+namespace CheckYourEligibility.API.UseCases;
+
+/// <summary>
+///     Interface for creating or updating a user.
+/// </summary>
+public interface ICreateRateLimitEvent
+{
+    /// <summary>
+    ///     Execute the use case.
+    /// </summary>
+    /// <param name="model"></param>
+    /// <returns></returns>
+    Task<> Execute(RateLimitEvent item);
+}
+
+public class CreateRateLimitEventUseCase : ICreateRateLimitEvent
+{
+    private readonly IRateLimit _rateLimitGateway;
+
+    public CreateRateLimitEventUseCase(IRateLimit rateLimitGateway)
+    {
+        _rateLimitGateway = rateLimitGateway;
+    }
+
+    public async Task<> Execute(RateLimitEvent item)
+    {
+        await _rateLimitGateway.Create(item);
+        return;
+    }
+}

--- a/CheckYourEligibility.API/appsettings.json
+++ b/CheckYourEligibility.API/appsettings.json
@@ -74,6 +74,10 @@
     "Templates": {
     }
   },
+  "RateLimit": {
+    "Policies": {
+    }
+  },
   "TestData": {
     "LastName": "",
     "Outcomes": {

--- a/docs/Rate-limit-guide.md
+++ b/docs/Rate-limit-guide.md
@@ -1,0 +1,27 @@
+# Rate Limiting Documentation
+
+## Overiview
+The Rate Limiting used in this project is implemented from scratch as middleware, using the sql database as a means to synchronise rate limiting information across nodes running in parallel when horizontally scaled. The implementation tries to follow the genral concepts of the dotnet rate limiter implementation, so that it may be used in the future if support for horizontal scaling is added to the package.
+
+The rate limit policy is based on the loacl authority id provided in the scopes when authenticating, meaning that limits are applied per authority rather than per IP, as some authorities use multiple IPs and some IPs serve multiple authorities. Multiple policies can be configured, in Program.cs, and each specifies PartitionName, WindowLength, and PermitLimit.
+
+The rateLimiters are currently applied in sequence in the middleware, meaning that a request must pass all applicable rate limit policies to be able to be accepted by the API. A request that fails to meet the rate limiting policy will return a 429 response, with a `retry-after` header that specifies the WindowLength of the policy on which it failed. It may be possible that a request would have been rejected by multiple rate limit policies, but only the first policy that rejects it will determine the response headers.
+
+## Implementation details
+### Policy parameters
+`PartitionName` is the name of the policy, and is used in conjunction with the local authority id to track events that apply to the particular rate limiter and client. It should have a descriptive name of what the policy is checking for
+`WindowLength` is the size of the timeframe over which to check for requests that have been received when determining whether the rate limit has been exceeded.
+`PermitLimit` is the maximum number of permits that can be used by requests for the policy over the given windowLength. (Note: In this implementation of rate limiting, a request can use multiple permits)
+
+### Storage and validation
+Each request that matches a policy is written to the RateLimitEvents table, regardless of the outcome. Each evet contains the PartitionName (When combined with the local authority id), the timestamp of the event, the size of the query (E.g. the number of checks being submitted) , and whether the event was accepted or rejected by the limiter. Each request will have a corresponding event in the table for each rate limit policy which checks it.
+
+When an event is received, the RateLimitEvents table is queried to find the sum of all the qurySizes from events in the same partition withing the WindowLength. If the result + the query size of the request currently being processed is less than or equal to the PermitLimit, then the request is allowed to continue processing. Otherwise a 429 response is returned.
+
+### Middleware ordering
+Typically ratelimiting solutions would occurr before request authorisation so that it can mitigate the risk of malicious use e.g. DoS attacks. In this implementation, the rate limiting occurs after the authentication step because the rate limiter uses the authentication context to determine which partition to separate requests into i.e. it uses the local authority id from the scopes supplied during authentication. There is a suitable rate limiting policiy in Azure that mitigates the risk of DoS attacks instead.
+
+### Possible future extensions
+- Determine retry period via a db query to find when the window has capcaity to handle the request
+- Integrate with the dotnet rate limit framework, using the table that has been created to synchornise across horizontally scaled nodes
+- Create builder methods for ratelimiters so that all rate limiters can be set-up and configured from the definitions in the appsettings


### PR DESCRIPTION
Ticket: https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_workitems/edit/214201

- Implements rate limiting on check and bulk-check endpoints
- rate limits are based on the local authority id that is provided for authentication
- Two rate limits, per-minute and per-hour are set up with default values
- RateLimitEvents table is created via migration