### PR TITLE
Write WF eligibility dates to checkData if present

### DIFF
--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -92,6 +92,7 @@ public class CheckEligibilityGateway : BaseGateway, ICheckEligibility
                     checkData.GracePeriodEndDate = wfEvent.GracePeriodEndDate.ToString("yyyy-MM-dd");
                     checkData.LastName = wfEvent.ParentLastName;
                     checkData.SubmissionDate = wfEvent.SubmissionDate.ToString("yyyy-MM-dd");
+                    item.CheckData = JsonConvert.SerializeObject(checkData);
                 }
             }
 

--- a/tests/cypress/API/03 - Eligibility/GetEligibilitySoftCheck.cy.ts
+++ b/tests/cypress/API/03 - Eligibility/GetEligibilitySoftCheck.cy.ts
@@ -1,6 +1,7 @@
 // /FreeSchoolMeals/{guid
 import { getandVerifyBearerToken } from '../../support/apiHelpers';
-import { validLoginRequestBody, validHMRCRequestBody, validWorkingFamiliesRequestBody } from '../../support/requestBodies';
+import { validLoginRequestBody, validHMRCRequestBody, validWorkingFamiliesRequestBody, validWorkingFamiliesRequestBodyEligible }
+    from '../../support/requestBodies';
 
 
 describe('GET eligibility soft check by Guid', () => {
@@ -27,7 +28,7 @@ describe('GET eligibility soft check by Guid', () => {
             });
         });
     })
-    it('Verify 200 Success response is returned with valid guid Working Families', () => {
+    it('Verify 200 Success response is returned with valid guid Working Families notFound', () => {
         //Get token
         getandVerifyBearerToken('/oauth2/token', validLoginRequestBody).then((token) => {
             //Make post request for eligibility check
@@ -42,7 +43,28 @@ describe('GET eligibility soft check by Guid', () => {
                     cy.apiRequest('GET', `check/${Guid}`, {}, token).then((newResponse) => {
                         // Assert the response 
                         cy.verifyApiResponseCode(newResponse, 200)
-                        cy.verifyGetEligibilityWFCheckResponseData(newResponse, requestBody)
+                        cy.verifyGetEligibilityWFCheckResponseDataNotFound(newResponse, requestBody)
+                    })
+                });
+            });
+        });
+    })
+    it('Verify 200 Success response is returned with valid guid Working Families found', () => {
+        //Get token
+        getandVerifyBearerToken('/oauth2/token', validLoginRequestBody).then((token) => {
+            //Make post request for eligibility check
+            cy.log(Cypress.env('lastName'));
+            const requestBody = validWorkingFamiliesRequestBodyEligible();
+            cy.apiRequest('POST', 'check/working-families', requestBody, token).then((response) => {
+                cy.verifyApiResponseCode(response, 202);
+                //extract Guid
+                cy.extractGuid(response);
+                //make get request using the guid 
+                cy.get('@Guid').then((Guid) => {
+                    cy.apiRequest('GET', `check/${Guid}`, {}, token).then((newResponse) => {
+                        // Assert the response 
+                        cy.verifyApiResponseCode(newResponse, 200)
+                        cy.verifyGetEligibilityWFCheckResponseDataFound(newResponse, requestBody)
                     })
                 });
             });

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -8,7 +8,8 @@ declare namespace Cypress {
     verifyPostEligibilityBulkCheckResponse(response: any): Chainable<any>;
     extractGuid(response: any): Chainable<string>;
     verifyGetEligibilityCheckResponseData(response: any, requestData: any): Chainable<void>;
-    verifyGetEligibilityWFCheckResponseData(response: any, requestData: any): Chainable<void>;
+    verifyGetEligibilityWFCheckResponseDataNotFound(response: any, requestData: any): Chainable<void>;
+    verifyGetEligibilityWFCheckResponseDataFound(response: any, requestData: any): Chainable<void>;
     verifyApiResponseCode(response: any, expectedStatus: number): Chainable<void>;
     verifyGetEligibilityCheckStatusResponse(response: any): Chainable<void>;
     createEligibilityBulkCheckAndGetResults(loginUrl: string, loginRequestBody: any, eligibilityBulkCheckUrl: string, eligibilityCheckBulkRequestBody: any): Chainable<any>;
@@ -137,7 +138,7 @@ Cypress.Commands.add('verifyGetEligibilityCheckResponseData', (response, request
   expect(responseLinks).to.have.property('get_EligibilityCheckStatus');
 });
 
-Cypress.Commands.add('verifyGetEligibilityWFCheckResponseData', (response, requestData) => {
+Cypress.Commands.add('verifyGetEligibilityWFCheckResponseDataNotFound', (response, requestData) => {
   // Verify body has data and links properties
   expect(response.body).to.have.property('data');
   expect(response.body).to.have.property('links');
@@ -153,6 +154,35 @@ Cypress.Commands.add('verifyGetEligibilityWFCheckResponseData', (response, reque
   expect(responseData).to.have.property('lastName', requestData.data.lastName.toUpperCase());
   expect(responseData).to.have.property('dateOfBirth', requestData.data.dateOfBirth);
   expect(responseData).to.have.property('eligibilityCode', requestData.data.eligibilityCode);
+  expect(responseData).to.have.property('status', 'notFound');
+  expect(responseData).to.have.property('created');
+  
+
+  // Verify links properties
+  expect(responseLinks).to.have.property('get_EligibilityCheck');
+  expect(responseLinks).to.have.property('put_EligibilityCheckProcess');
+  expect(responseLinks).to.have.property('get_EligibilityCheckStatus');
+});
+
+Cypress.Commands.add('verifyGetEligibilityWFCheckResponseDataFound', (response, requestData) => {
+  // Verify body has data and links properties
+  expect(response.body).to.have.property('data');
+  expect(response.body).to.have.property('links');
+  const responseData = response.body.data;
+  const responseLinks = response.body.links;
+
+  // Calculate total number of elements in data and links
+  const totalElements = Object.keys(responseData).length + Object.keys(responseLinks).length;
+  // Verfiy total number of elements
+  cy.verifyTotalElements(totalElements, 12);
+
+  expect(responseData).to.have.property('nationalInsuranceNumber', requestData.data.nationalInsuranceNumber);
+  expect(responseData).to.have.property('lastName', requestData.data.lastName.toUpperCase());
+  expect(responseData).to.have.property('dateOfBirth', requestData.data.dateOfBirth);
+  expect(responseData).to.have.property('eligibilityCode', requestData.data.eligibilityCode);
+  expect(responseData).to.have.property('validityStartDate');
+  expect(responseData).to.have.property('validityEndDate');
+  expect(responseData).to.have.property('gracePeriodEndDate');
   expect(responseData).to.have.property('status');
   expect(responseData).to.have.property('created');
   

--- a/tests/cypress/support/requestBodies.ts
+++ b/tests/cypress/support/requestBodies.ts
@@ -152,6 +152,16 @@ export function validWorkingFamiliesRequestBody() {
         }
     }
 }
+export function validWorkingFamiliesRequestBodyEligible() {
+    return {
+        data: {
+             nationalInsuranceNumber: "AA123456C",
+             dateOfBirth: "2022-06-07",
+             eligibilityCode: "90012345671",
+             lastName: "TestE"
+        }
+    }
+}
 export function validWorkingFamiliesNullLastnameRequestBody() {
     return {
         data: {


### PR DESCRIPTION
Ticket: https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_backlogs/backlog/ECS/Stories?workitem=232769

- Adds the eligibility dates to the checkData for the EligibiltyCheck so that they can be retrieved when calling /check/{guid}
- This is already done when processing the check (we may want to look into redundancies there) but when the check has already been hashed/ or has not been processed yet, then the data from the WorkingFamiliesEvent is not yet present in the EligibilityCheck table