### PR TITLE
234641 rate limit events garbage collector

### DIFF
--- a/CheckYourEligibility.API.Tests/Controllers/AdministrationControllerTests.cs
+++ b/CheckYourEligibility.API.Tests/Controllers/AdministrationControllerTests.cs
@@ -16,6 +16,7 @@ public class AdministrationControllerTests : TestBase.TestBase
 {
     private Mock<IAudit> _mockAuditGateway;
     private Mock<ICleanUpEligibilityChecksUseCase> _mockCleanUpEligibilityChecksUseCase;
+    private Mock<ICleanUpRateLimitEventsUseCase> _mockCleanUpRateLimitEventsUseCase;
     private Mock<IImportEstablishmentsUseCase> _mockImportEstablishmentsUseCase;
     private Mock<IImportFsmHMRCDataUseCase> _mockImportFsmHMRCDataUseCase;
     private Mock<IImportFsmHomeOfficeDataUseCase> _mockImportFsmHomeOfficeDataUseCase;
@@ -27,6 +28,7 @@ public class AdministrationControllerTests : TestBase.TestBase
     public void Setup()
     {
         _mockCleanUpEligibilityChecksUseCase = new Mock<ICleanUpEligibilityChecksUseCase>(MockBehavior.Strict);
+        _mockCleanUpRateLimitEventsUseCase = new Mock<ICleanUpRateLimitEventsUseCase>(MockBehavior.Strict);
         _mockImportEstablishmentsUseCase = new Mock<IImportEstablishmentsUseCase>(MockBehavior.Strict);
         _mockImportFsmHomeOfficeDataUseCase = new Mock<IImportFsmHomeOfficeDataUseCase>(MockBehavior.Strict);
         _mockImportFsmHMRCDataUseCase = new Mock<IImportFsmHMRCDataUseCase>(MockBehavior.Strict);
@@ -35,6 +37,7 @@ public class AdministrationControllerTests : TestBase.TestBase
         _mockAuditGateway = new Mock<IAudit>(MockBehavior.Strict);
         _sut = new AdministrationController(
             _mockCleanUpEligibilityChecksUseCase.Object,
+            _mockCleanUpRateLimitEventsUseCase.Object,
             _mockImportEstablishmentsUseCase.Object,
             _mockImportFsmHomeOfficeDataUseCase.Object,
             _mockImportFsmHMRCDataUseCase.Object,
@@ -62,6 +65,22 @@ public class AdministrationControllerTests : TestBase.TestBase
 
         // Act
         var response = await _sut.CleanUpEligibilityChecks();
+
+        // Assert
+        response.Should().BeEquivalentTo(expectedResult);
+    }
+
+    [Test]
+    public async Task Given_CleanUpRateLimitEvents_Should_Return_Status200OK()
+    {
+        // Arrange
+        _mockCleanUpRateLimitEventsUseCase.Setup(cs => cs.Execute()).Returns(Task.CompletedTask);
+
+        var expectedResult = new ObjectResult(new MessageResponse { Data = $"{Admin.RateLimitEventCleanse}" })
+        { StatusCode = StatusCodes.Status200OK };
+
+        // Act
+        var response = await _sut.CleanUpRateLimitEvents();
 
         // Assert
         response.Should().BeEquivalentTo(expectedResult);

--- a/CheckYourEligibility.API.Tests/Gateways/RateLimiterGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/RateLimiterGatewayTests.cs
@@ -25,7 +25,7 @@ public class RateLimiterServiceTests : TestBase.TestBase
 
         var configForRLCleanUp = new Dictionary<string, string?>
         {
-            { "RateLimit.Retention_Days", "7" }
+            { "RateLimit:RetentionDays", "7" }
         };
 
         var _configuration = new ConfigurationBuilder()

--- a/CheckYourEligibility.API.Tests/Gateways/RateLimiterGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/RateLimiterGatewayTests.cs
@@ -41,7 +41,7 @@ public class RateLimiterServiceTests : TestBase.TestBase
         // Arrange
         var guid = _fixture.Create<Guid>().ToString();
         var checkEvent = _fixture.Create<RateLimitEvent>();
-        checkEvent.RateLimitEventId = guid; 
+        checkEvent.RateLimitEventId = guid;
         // Act
         await _sut.Create(checkEvent);
         // Assert
@@ -113,5 +113,49 @@ public class RateLimiterServiceTests : TestBase.TestBase
 
         // Assert
         response.Should().Be(5);
+    }
+
+    [Test]
+    public async Task Given_CleanUpRateLimitEvents_Should_Return_Pass()
+    {
+        // Arrange
+
+        // Act
+        await _sut.CleanUpRateLimitEvents();
+
+        // Assert
+        Assert.Pass();
+    }
+
+    [Test]
+    public async Task Given_CleanUpRateLimitEvents_Should_Remove_Old_Events()
+    {
+        // Arrange
+        var checkEvent = _fixture.Create<RateLimitEvent>();
+        checkEvent.TimeStamp = DateTime.UtcNow.AddDays(-10);
+        _fakeInMemoryDb.RateLimitEvents.Add(checkEvent);
+        _fakeInMemoryDb.SaveChanges();
+
+        // Act
+        await _sut.CleanUpRateLimitEvents();
+
+        // Assert
+        _fakeInMemoryDb.RateLimitEvents.Count().Should().Be(0);
+    }
+    
+    [Test]
+    public async Task Given_CleanUpRateLimitEvents_Should_Keep_Current_Events()
+    {
+        // Arrange
+        var checkEvent = _fixture.Create<RateLimitEvent>();
+        checkEvent.TimeStamp = DateTime.UtcNow.AddDays(-6);
+        _fakeInMemoryDb.RateLimitEvents.Add(checkEvent);
+        _fakeInMemoryDb.SaveChanges();
+
+        // Act
+        await _sut.CleanUpRateLimitEvents();
+
+        // Assert
+        _fakeInMemoryDb.RateLimitEvents.Count().Should().Be(1);
     }
 }

--- a/CheckYourEligibility.API.Tests/Usecases/CleanUpRateLimitEventsUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/CleanUpRateLimitEventsUseCaseTests.cs
@@ -1,0 +1,47 @@
+using AutoFixture;
+using CheckYourEligibility.API.Domain.Enums;
+using CheckYourEligibility.API.Gateways.Interfaces;
+using CheckYourEligibility.API.UseCases;
+using Moq;
+
+namespace CheckYourEligibility.API.Tests.UseCases;
+
+[TestFixture]
+public class CleanUpRateLimitEventsChecksUseCaseTests : TestBase.TestBase
+{
+    [SetUp]
+    public void Setup()
+    {
+        _mockGateway = new Mock<IRateLimit>(MockBehavior.Strict);
+        _mockAuditGateway = new Mock<IAudit>(MockBehavior.Strict);
+        _sut = new CleanUpRateLimitEventsUseCase(_mockGateway.Object, _mockAuditGateway.Object);
+        _fixture = new Fixture();
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        _mockGateway.VerifyAll();
+        _mockAuditGateway.VerifyAll();
+    }
+
+    private Mock<IRateLimit> _mockGateway;
+    private Mock<IAudit> _mockAuditGateway;
+    private CleanUpRateLimitEventsUseCase _sut;
+    private Fixture _fixture;
+
+    [Test]
+    public async Task Execute_Should_Call_CleanUpRateLimitEvents_On_gateway()
+    {
+        // Arrange
+        _mockGateway.Setup(s => s.CleanUpRateLimitEvents()).Returns(Task.CompletedTask);
+        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty))
+            .ReturnsAsync(_fixture.Create<string>());
+
+        // Act
+        await _sut.Execute();
+
+        // Assert
+        _mockGateway.Verify(s => s.CleanUpRateLimitEvents(), Times.Once);
+    }
+}

--- a/CheckYourEligibility.API/Controllers/AdministrationController.cs
+++ b/CheckYourEligibility.API/Controllers/AdministrationController.cs
@@ -19,6 +19,7 @@ namespace CheckYourEligibility.API.Controllers;
 public class AdministrationController : BaseController
 {
     private readonly ICleanUpEligibilityChecksUseCase _cleanUpEligibilityChecksUseCase;
+    private readonly ICleanUpRateLimitEventsUseCase _cleanUpRateLimitEventsUseCase;
     private readonly IImportEstablishmentsUseCase _importEstablishmentsUseCase;
     private readonly IImportFsmHMRCDataUseCase _importFsmHMRCDataUseCase;
     private readonly IImportFsmHomeOfficeDataUseCase _importFsmHomeOfficeDataUseCase;
@@ -28,12 +29,14 @@ public class AdministrationController : BaseController
     ///     Constructor for AdministrationController
     /// </summary>
     /// <param name="cleanUpEligibilityChecksUseCase"></param>
+    /// <param name="cleanUpRateLimitEventsUseCase"></param>
     /// <param name="importEstablishmentsUseCase"></param>
     /// <param name="importFsmHomeOfficeDataUseCase"></param>
     /// <param name="importFsmHMRCDataUseCase"></param>
     /// <param name="audit"></param>
     public AdministrationController(
         ICleanUpEligibilityChecksUseCase cleanUpEligibilityChecksUseCase,
+        ICleanUpRateLimitEventsUseCase cleanUpRateLimitEventsUseCase,
         IImportEstablishmentsUseCase importEstablishmentsUseCase,
         IImportFsmHomeOfficeDataUseCase importFsmHomeOfficeDataUseCase,
         IImportFsmHMRCDataUseCase importFsmHMRCDataUseCase,
@@ -41,6 +44,7 @@ public class AdministrationController : BaseController
         IAudit audit) : base(audit)
     {
         _cleanUpEligibilityChecksUseCase = cleanUpEligibilityChecksUseCase;
+        _cleanUpRateLimitEventsUseCase = cleanUpRateLimitEventsUseCase;
         _importEstablishmentsUseCase = importEstablishmentsUseCase;
         _importFsmHomeOfficeDataUseCase = importFsmHomeOfficeDataUseCase;
         _importFsmHMRCDataUseCase = importFsmHMRCDataUseCase;
@@ -59,6 +63,21 @@ public class AdministrationController : BaseController
     {
         await _cleanUpEligibilityChecksUseCase.Execute();
         return new ObjectResult(new MessageResponse { Data = $"{Admin.EligibilityChecksCleanse}" })
+        { StatusCode = StatusCodes.Status200OK };
+    }
+
+    /// <summary>
+    ///     Deletes all old Rate Limit Events based on the service configuration
+    /// </summary>
+    /// <returns></returns>
+    [ProducesResponseType(typeof(int), (int)HttpStatusCode.OK)]
+    [Consumes("application/json", "application/vnd.api+json;version=1.0")]
+    [HttpPut("/admin/clean-up-rate-limit-events")]
+    [Authorize(Policy = PolicyNames.RequireAdminScope)]
+    public async Task<ActionResult> CleanUpRateLimitEvents()
+    {
+        await _cleanUpRateLimitEventsUseCase.Execute();
+        return new ObjectResult(new MessageResponse { Data = $"{Admin.RateLimitEventCleanse}" })
         { StatusCode = StatusCodes.Status200OK };
     }
 

--- a/CheckYourEligibility.API/Domain/Constants/Admin.cs
+++ b/CheckYourEligibility.API/Domain/Constants/Admin.cs
@@ -6,6 +6,7 @@ public static class Admin
 {
     public const string EstablishmentFileProcessed = "Establishment File Processed.";
     public const string EligibilityChecksCleanse = "EligibilityChecks deleted based on configuration settings.";
+    public const string RateLimitEventCleanse = "RateLimitEvents deleted based on configuration settings.";
     public const string CsvfileRequired = "Csv data file is required.";
     public const string HomeOfficeFileProcessed = "HomeOffice File Processed.";
     public const string XmlfileRequired = "Xml data file is required.";

--- a/CheckYourEligibility.API/Gateways/AdministrationGateway.cs
+++ b/CheckYourEligibility.API/Gateways/AdministrationGateway.cs
@@ -25,18 +25,26 @@ public class AdministrationGateway : IAdministration
 
     public async Task CleanUpEligibilityChecks()
     {
-        var checkDate =
-            DateTime.UtcNow.AddDays(
-                -_configuration.GetValue<int>($"DataCleanseDaysSoftCheck_Status_{CheckEligibilityStatus.eligible}"));
-        var items = _db.CheckEligibilities.Where(x => x.Created <= checkDate);
-        _db.CheckEligibilities.RemoveRange(items);
-        await _db.SaveChangesAsync();
+        var eligibileRetentionDays = _configuration.GetValue<int>($"DataCleanseDaysSoftCheck_Status_{CheckEligibilityStatus.eligible}");
+        if (eligibileRetentionDays > 0)
+        {
+            var checkDate =
+                DateTime.UtcNow.AddDays(
+                    -eligibileRetentionDays);
+            var items = _db.CheckEligibilities.Where(x => x.Created <= checkDate);
+            _db.CheckEligibilities.RemoveRange(items);
+            await _db.SaveChangesAsync();
+        }
 
-        checkDate = DateTime.UtcNow.AddDays(
-            -_configuration.GetValue<int>($"DataCleanseDaysSoftCheck_Status_{CheckEligibilityStatus.parentNotFound}"));
-        items = _db.CheckEligibilities.Where(x => x.Created <= checkDate);
-        _db.CheckEligibilities.RemoveRange(items);
-        await _db.SaveChangesAsync();
+        var notFoundRetentionDays = _configuration.GetValue<int>($"DataCleanseDaysSoftCheck_Status_{CheckEligibilityStatus.parentNotFound}");
+        if (notFoundRetentionDays > 0)
+        {
+            var checkDate = DateTime.UtcNow.AddDays(
+                -notFoundRetentionDays);
+            var items = _db.CheckEligibilities.Where(x => x.Created <= checkDate);
+            _db.CheckEligibilities.RemoveRange(items);
+            await _db.SaveChangesAsync();
+        }
     }
 
     [ExcludeFromCodeCoverage(Justification = "Use of bulk operations")]

--- a/CheckYourEligibility.API/Gateways/Interfaces/IRateLimit.cs
+++ b/CheckYourEligibility.API/Gateways/Interfaces/IRateLimit.cs
@@ -7,4 +7,8 @@ public interface IRateLimit
     Task Create(RateLimitEvent item);
     Task UpdateStatus(string guid, bool accepted);
     Task<int> GetQueriesInWindow(string partition, DateTime eventTimeStamp, TimeSpan windowLength);
+<<<<<<< Updated upstream
+=======
+    Task CleanUpRateLimitEvents();
+>>>>>>> Stashed changes
 }

--- a/CheckYourEligibility.API/Gateways/Interfaces/IRateLimit.cs
+++ b/CheckYourEligibility.API/Gateways/Interfaces/IRateLimit.cs
@@ -7,8 +7,5 @@ public interface IRateLimit
     Task Create(RateLimitEvent item);
     Task UpdateStatus(string guid, bool accepted);
     Task<int> GetQueriesInWindow(string partition, DateTime eventTimeStamp, TimeSpan windowLength);
-<<<<<<< Updated upstream
-=======
     Task CleanUpRateLimitEvents();
->>>>>>> Stashed changes
 }

--- a/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
+++ b/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
@@ -67,10 +67,13 @@ public class RateLimitGateway : BaseGateway, IRateLimit
     /// <returns></returns>
     public async Task CleanUpRateLimitEvents()
     {
-        var retentionCutOff = DateTime.UtcNow.AddDays(-7); //Clean out records older than a week 
-        //TODO: Determine based on appsettings config
-        var items = _db.RateLimitEvents.Where(x => x.TimeStamp < retentionCutOff);
-        _db.RateLimitEvents.RemoveRange(items);
-        await _db.SaveChangesAsync();
+        var retentionDays = _configuration.GetValue<int>("RateLimit.Retention_Days");
+        if (retentionDays > 0)
+        {
+            var retentionCutOff = DateTime.UtcNow.AddDays(-retentionDays);
+            var items = _db.RateLimitEvents.Where(x => x.TimeStamp < retentionCutOff);
+            _db.RateLimitEvents.RemoveRange(items);
+            await _db.SaveChangesAsync();
+        }
     }
 }

--- a/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
+++ b/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
@@ -67,7 +67,7 @@ public class RateLimitGateway : BaseGateway, IRateLimit
     /// <returns></returns>
     public async Task CleanUpRateLimitEvents()
     {
-        var retentionDays = _configuration.GetValue<int>("RateLimit.Retention_Days");
+        var retentionDays = _configuration.GetValue<int>("RateLimit:RetentionDays");
         if (retentionDays > 0)
         {
             var retentionCutOff = DateTime.UtcNow.AddDays(-retentionDays);

--- a/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
+++ b/CheckYourEligibility.API/Gateways/RateLimitGateway.cs
@@ -25,7 +25,11 @@ public class RateLimitGateway : BaseGateway, IRateLimit
         _db.RateLimitEvents.Add(item);
         await _db.SaveChangesAsync();
     }
+<<<<<<< Updated upstream
     
+=======
+
+>>>>>>> Stashed changes
     /// <summary>
     ///     Sets the status of the rateLimitEvent, reflecting the decision made of whether to permit the request
     /// </summary>
@@ -53,8 +57,25 @@ public class RateLimitGateway : BaseGateway, IRateLimit
     public async Task<int> GetQueriesInWindow(string partition, DateTime eventTimeStamp, TimeSpan windowLength)
     {
         return _db.RateLimitEvents.Where(x => x.PartitionName == partition &&
+<<<<<<< Updated upstream
             x.TimeStamp < eventTimeStamp && 
             x.TimeStamp >= eventTimeStamp.Subtract(windowLength))
             .Sum(x => x.QuerySize);
     }
+=======
+            x.TimeStamp < eventTimeStamp &&
+            x.TimeStamp >= eventTimeStamp.Subtract(windowLength))
+            .Sum(x => x.QuerySize);
+    }
+
+    /// <summary>
+    ///     Removes all events that are beyond the given retention period
+    /// </summary>
+    /// <returns></returns>
+    public async Task CleanUpRateLimitEvents()
+    {
+        var retentionPeriod = TimeSpan.FromDays(7); //Clean out records older than a week //TODO: Determine based on appsettings config
+        //TODO: Implement
+    }
+>>>>>>> Stashed changes
 }

--- a/CheckYourEligibility.API/Program.cs
+++ b/CheckYourEligibility.API/Program.cs
@@ -178,6 +178,7 @@ builder.Services.AddScoped<IProcessEligibilityCheckUseCase, ProcessEligibilityCh
 builder.Services.AddScoped<IGetEligibilityCheckItemUseCase, GetEligibilityCheckItemUseCase>();
 builder.Services.AddScoped<ISendNotificationUseCase, SendNotificationUseCase>();
 builder.Services.AddScoped<ICreateRateLimitEventUseCase, CreateRateLimitEventUseCase>();
+builder.Services.AddScoped<ICleanUpRateLimitEventsUseCase, CleanUpRateLimitEventsUseCase>();
 
 builder.Services.AddScoped<IValidator<IEligibilityServiceType>, CheckEligibilityRequestDataValidator>();
 

--- a/CheckYourEligibility.API/Usecases/CleanUpRateLimitEventsUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CleanUpRateLimitEventsUseCase.cs
@@ -1,0 +1,27 @@
+using CheckYourEligibility.API.Domain.Enums;
+using CheckYourEligibility.API.Gateways.Interfaces;
+
+namespace CheckYourEligibility.API.UseCases;
+
+public interface ICleanUpRateLimitEventsUseCase
+{
+    Task Execute();
+}
+
+public class CleanUpRateLimitEventsUseCase : ICleanUpRateLimitEventsUseCase
+{
+    private readonly IAudit _auditGateway;
+    private readonly IRateLimit _gateway;
+
+    public CleanUpRateLimitEventsUseCase(IRateLimit Gateway, IAudit auditGateway)
+    {
+        _gateway = Gateway;
+        _auditGateway = auditGateway;
+    }
+
+    public async Task Execute()
+    {
+        await _gateway.CleanUpRateLimitEvents();
+        await _auditGateway.CreateAuditEntry(AuditType.Administration, string.Empty);
+    }
+}

--- a/CheckYourEligibility.API/appsettings.json
+++ b/CheckYourEligibility.API/appsettings.json
@@ -78,7 +78,8 @@
   },
   "RateLimit": {
     "Policies": {
-    }
+    },
+    "RetentionDays": 7
   },
   "TestData": {
     "LastName": "",


### PR DESCRIPTION
Ticket: https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_workitems/edit/234641

- Creates a new endpoint that removes RateLimitEvents older than a configured limit
- Implements an extra check for valid configuration on existing clean up use case