### PR TITLE
237148 fix mat table import

### DIFF
--- a/CheckYourEligibility.API/Domain/MultiAcademyTrust.cs
+++ b/CheckYourEligibility.API/Domain/MultiAcademyTrust.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
 
 namespace CheckYourEligibility.API.Domain;
@@ -7,7 +8,9 @@ namespace CheckYourEligibility.API.Domain;
 [ExcludeFromCodeCoverage(Justification = "Data Model.")]
 public class MultiAcademyTrust
 {
-    [Key] public int UID { get; set; }
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public int UID { get; set; }
     public string Name { get; set; }
     public virtual Collection<MultiAcademyTrustSchool> MultiAcademyTrustSchools { get; set; }
 }

--- a/CheckYourEligibility.API/Migrations/20250929105701_RemoveMatTables.Designer.cs
+++ b/CheckYourEligibility.API/Migrations/20250929105701_RemoveMatTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CheckYourEligibility.API.Migrations
 {
     [DbContext(typeof(EligibilityCheckContext))]
-    partial class EligibilityCheckContextModelSnapshot : ModelSnapshot
+    [Migration("20250929105701_RemoveMatTables")]
+    partial class RemoveMatTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CheckYourEligibility.API/Migrations/20250929105701_RemoveMatTables.cs
+++ b/CheckYourEligibility.API/Migrations/20250929105701_RemoveMatTables.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CheckYourEligibility.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveMatTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MultiAcademyTrustSchools");
+
+            migrationBuilder.DropTable(
+                name: "MultiAcademyTrusts");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MultiAcademyTrusts",
+                columns: table => new
+                {
+                    UID = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MultiAcademyTrusts", x => x.UID);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MultiAcademyTrustSchools",
+                columns: table => new
+                {
+                    ID = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    TrustId = table.Column<int>(type: "int", nullable: false),
+                    SchoolId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MultiAcademyTrustSchools", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_MultiAcademyTrustSchools_MultiAcademyTrusts_TrustId",
+                        column: x => x.TrustId,
+                        principalTable: "MultiAcademyTrusts",
+                        principalColumn: "UID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MultiAcademyTrustSchools_TrustId",
+                table: "MultiAcademyTrustSchools",
+                column: "TrustId");
+        }
+    }
+}

--- a/CheckYourEligibility.API/Migrations/20250929115727_RecreateMatTables.Designer.cs
+++ b/CheckYourEligibility.API/Migrations/20250929115727_RecreateMatTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CheckYourEligibility.API.Migrations
 {
     [DbContext(typeof(EligibilityCheckContext))]
-    partial class EligibilityCheckContextModelSnapshot : ModelSnapshot
+    [Migration("20250929115727_RecreateMatTables")]
+    partial class RecreateMatTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CheckYourEligibility.API/Migrations/20250929115727_RecreateMatTables.cs
+++ b/CheckYourEligibility.API/Migrations/20250929115727_RecreateMatTables.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CheckYourEligibility.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class RecreateMatTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MultiAcademyTrusts",
+                columns: table => new
+                {
+                    UID = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MultiAcademyTrusts", x => x.UID);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MultiAcademyTrustSchools",
+                columns: table => new
+                {
+                    ID = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    TrustId = table.Column<int>(type: "int", nullable: false),
+                    SchoolId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MultiAcademyTrustSchools", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_MultiAcademyTrustSchools_MultiAcademyTrusts_TrustId",
+                        column: x => x.TrustId,
+                        principalTable: "MultiAcademyTrusts",
+                        principalColumn: "UID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MultiAcademyTrustSchools_TrustId",
+                table: "MultiAcademyTrustSchools",
+                column: "TrustId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MultiAcademyTrustSchools");
+
+            migrationBuilder.DropTable(
+                name: "MultiAcademyTrusts");
+        }
+    }
+}


### PR DESCRIPTION
Ticket: https://dfe-gov-uk.visualstudio.com/Solutions%20Development/_workitems/edit/237148

- Removes autogenerated key values so trust Ids stay consistent with import data
- Requires dropping MAT tables and recreating without the constraint. There is a migration for that stage