### PR TITLE
241824 add reason for capi mapped status

### DIFF
--- a/CheckYourEligibility.API.Tests/Gateways/CheckEligibilityServiceTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/CheckEligibilityServiceTests.cs
@@ -111,6 +111,7 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
     {
         // Arrange
         var request = _fixture.Create<CheckEligibilityRequestData>();
+        var citizenResponse = _fixture.Create<CAPICitizenResponse>();
         request.DateOfBirth = "1970-02-01";
         request.NationalAsylumSeekerServiceNumber = null;
 
@@ -123,11 +124,11 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         });
         await _fakeInMemoryDb.SaveChangesAsync();
         _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(), Guid.NewGuid().ToString()))
-            .ReturnsAsync(Guid.NewGuid().ToString());
+            .ReturnsAsync(citizenResponse);
         var result = new StatusCodeResult(StatusCodes.Status200OK);
         _moqDwpGateway.Setup(x => x.GetCitizenClaims(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
-            .ReturnsAsync(result);
+            .ReturnsAsync((result, string.Empty));
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>())).ReturnsAsync("");
         // Act/Assert
         var response = await _sut.PostCheck(request);
@@ -160,6 +161,7 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
     {
         // Arrange
         var request = _fixture.Create<CheckEligibilityRequestData>();
+        var citizenResponse = _fixture.Create<CAPICitizenResponse>();
         request.Type = CheckEligibilityType.FreeSchoolMeals;
         request.DateOfBirth = "1970-02-01";
         request.NationalAsylumSeekerServiceNumber = null;
@@ -173,11 +175,11 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         });
         await _fakeInMemoryDb.SaveChangesAsync();
         _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(), It.IsAny<Guid>().ToString()))
-            .ReturnsAsync(Guid.NewGuid().ToString());
+            .ReturnsAsync(citizenResponse);
         var result = new StatusCodeResult(StatusCodes.Status200OK);
         _moqDwpGateway.Setup(x => x.GetCitizenClaims(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
-            .ReturnsAsync(result);
+            .ReturnsAsync((result, string.Empty));
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>())).ReturnsAsync("");
 
 
@@ -206,6 +208,7 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
     {
         // Arrange
         var request = _fixture.Create<CheckEligibilityRequestData>();
+        var citizenResponse = _fixture.Create<CAPICitizenResponse>();
         request.Type = CheckEligibilityType.FreeSchoolMeals;
         request.DateOfBirth = "1970-02-01";
         request.NationalAsylumSeekerServiceNumber = null;
@@ -223,11 +226,11 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
          await _fakeInMemoryDb.SaveChangesAsync();
         _moqEcsGateway.Setup(x => x.UseEcsforChecks).Returns("false");
         _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(),It.IsAny<Guid>().ToString()))
-            .ReturnsAsync(Guid.NewGuid().ToString());
+            .ReturnsAsync(citizenResponse);
         var result = new StatusCodeResult(StatusCodes.Status200OK);
         _moqDwpGateway.Setup(x => x.GetCitizenClaims(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<CheckEligibilityType>(),It.IsAny<string>()))
-            .ReturnsAsync(result);
+            .ReturnsAsync((result, string.Empty));
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>())).ReturnsAsync("");
 
         // Act
@@ -254,6 +257,7 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
     {
         // Arrange
         var request = _fixture.Create<CheckEligibilityRequestData>();
+        var citizenResponse = _fixture.Create<CAPICitizenResponse>();
         request.DateOfBirth = "1970-02-01";
         request.NationalAsylumSeekerServiceNumber = null;
         var key = string.IsNullOrEmpty(request.NationalInsuranceNumber)
@@ -268,11 +272,11 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         });
         await _fakeInMemoryDb.SaveChangesAsync();
         _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(),It.IsAny<Guid>().ToString()))
-            .ReturnsAsync(Guid.NewGuid().ToString());
+            .ReturnsAsync(citizenResponse);
         var result = new StatusCodeResult(StatusCodes.Status200OK);
         _moqDwpGateway.Setup(x => x.GetCitizenClaims(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<CheckEligibilityType>(),It.IsAny<Guid>().ToString()))
-            .ReturnsAsync(result);
+            .ReturnsAsync((result, string.Empty));
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>())).ReturnsAsync("");
 
 
@@ -466,6 +470,8 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         // Arrange
 
         var item = _fixture.Create<EligibilityCheck>();
+        var citizenResponse = _fixture.Create<CAPICitizenResponse>();
+        citizenResponse.CheckEligibilityStatus = CheckEligibilityStatus.parentNotFound;
         item.Type = CheckEligibilityType.FreeSchoolMeals;
         item.Status = CheckEligibilityStatus.queuedForProcessing;
         var fsm = _fixture.Create<CheckEligibilityRequestData>();
@@ -477,7 +483,7 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         await _fakeInMemoryDb.SaveChangesAsync();
         _moqEcsGateway.Setup(x => x.UseEcsforChecks).Returns("false");
         _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
-            .ReturnsAsync(CheckEligibilityStatus.parentNotFound.ToString());
+            .ReturnsAsync(citizenResponse);
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>())).ReturnsAsync("");
 
         // Act
@@ -500,6 +506,8 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         item.BulkCheck = null;
         
         var fsm = _fixture.Create<CheckEligibilityRequestData>();
+        CAPICitizenResponse citizenResponse = new();
+        citizenResponse.CheckEligibilityStatus = CheckEligibilityStatus.parentNotFound;
         fsm.DateOfBirth = "1990-01-01";
         fsm.Type = CheckEligibilityType.FreeSchoolMeals; // Force FSM type for this test
         var dataItem = GetCheckProcessData(fsm);
@@ -509,7 +517,7 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         _fakeInMemoryDb.SaveChanges();
         _moqEcsGateway.Setup(x => x.UseEcsforChecks).Returns("false");
         _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(),It.IsAny<string>()))
-            .ReturnsAsync(CheckEligibilityStatus.parentNotFound.ToString());
+            .ReturnsAsync(citizenResponse);
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>())).ReturnsAsync("");
 
         // Act
@@ -568,14 +576,15 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         audit.typeId = item.EligibilityCheckID;
         _fakeInMemoryDb.Audits.Add(audit);
 
+        CAPICitizenResponse citizenResponse =  _fixture.Create<CAPICitizenResponse>();      
         await _fakeInMemoryDb.SaveChangesAsync();
         _moqEcsGateway.Setup(x => x.UseEcsforChecks).Returns("validate");
         _moqEcsGateway.Setup(x => x.EcsCheck(It.IsAny<CheckProcessData>(), It.IsAny<CheckEligibilityType>())).ReturnsAsync(ecsSoapCheckResponse);
         _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
-     .ReturnsAsync("abcabcabc1234567abcabcabc1234567abcabcabc1234567abcabcabc1234567");
+     .ReturnsAsync(citizenResponse);
         _moqDwpGateway.Setup(x => x.GetCitizenClaims(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
-            .ReturnsAsync(capiResult);
+            .ReturnsAsync((capiResult, string.Empty));
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>())).ReturnsAsync("");
 
 
@@ -707,6 +716,7 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
     public void Given_validRequest_DWP_Process_Should_Return_updatedStatus_Eligible()
     {
         // Arrange
+        CAPICitizenResponse citizenResponse = _fixture.Create<CAPICitizenResponse>();
         var item = _fixture.Create<EligibilityCheck>();
         item.Status = CheckEligibilityStatus.queuedForProcessing;
         var fsm = _fixture.Create<CheckEligibilityRequestData>();
@@ -718,11 +728,11 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         _fakeInMemoryDb.SaveChangesAsync();
         _moqEcsGateway.Setup(x => x.UseEcsforChecks).Returns("false");
         _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(),It.IsAny<string>()))
-            .ReturnsAsync("abcabcabc1234567abcabcabc1234567abcabcabc1234567abcabcabc1234567");
+            .ReturnsAsync(citizenResponse);
         var result = new StatusCodeResult(StatusCodes.Status200OK);
         _moqDwpGateway.Setup(x => x.GetCitizenClaims(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
-            .ReturnsAsync(result);
+            .ReturnsAsync((result, string.Empty));
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>())).ReturnsAsync("");
 
 
@@ -738,6 +748,7 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
     {
         // Arrange
         var item = _fixture.Create<EligibilityCheck>();
+        var citizenResponse = _fixture.Create<CAPICitizenResponse>();
         item.Status = CheckEligibilityStatus.queuedForProcessing;
         var fsm = _fixture.Create<CheckEligibilityRequestData>();
         fsm.DateOfBirth = "1990-01-01";
@@ -748,11 +759,11 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         _fakeInMemoryDb.SaveChangesAsync();
         _moqEcsGateway.Setup(x => x.UseEcsforChecks).Returns("false");
         _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
-            .ReturnsAsync("abcabcabc1234567abcabcabc1234567abcabcabc1234567abcabcabc1234567");
+            .ReturnsAsync(citizenResponse);
         var result = new StatusCodeResult(StatusCodes.Status404NotFound);
         _moqDwpGateway.Setup(x => x.GetCitizenClaims(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
-            .ReturnsAsync(result);
+            .ReturnsAsync((result, string.Empty));
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>())).ReturnsAsync("");
 
 
@@ -774,15 +785,18 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         var dataItem = GetCheckProcessData(fsm);
         item.Type = CheckEligibilityType.FreeSchoolMeals;
         item.CheckData = JsonConvert.SerializeObject(dataItem);
+
+        CAPICitizenResponse citizenResponse = _fixture.Create<CAPICitizenResponse>();
+
         _fakeInMemoryDb.CheckEligibilities.Add(item);
         _fakeInMemoryDb.SaveChangesAsync();
         _moqEcsGateway.Setup(x => x.UseEcsforChecks).Returns("false");
         _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
-            .ReturnsAsync("abcabcabc1234567abcabcabc1234567abcabcabc1234567abcabcabc1234567");
+            .ReturnsAsync(citizenResponse);
         var result = new StatusCodeResult(StatusCodes.Status500InternalServerError);
         _moqDwpGateway.Setup(x => x.GetCitizenClaims(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<CheckEligibilityType>(),It.IsAny<string>()))
-            .ReturnsAsync(result);
+            .ReturnsAsync((result, string.Empty));
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>())).ReturnsAsync("");
 
 
@@ -797,6 +811,9 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
     public async Task Given_validRequest_DWP_Process_Should_Return_500_Failure_status_is_NotUpdated()
     {
         // Arrange
+        CAPICitizenResponse citizenResponse = _fixture.Create<CAPICitizenResponse>();
+        citizenResponse.CheckEligibilityStatus = CheckEligibilityStatus.error;
+
         var item = _fixture.Create<EligibilityCheck>();
         item.Status = CheckEligibilityStatus.queuedForProcessing;
         var fsm = _fixture.Create<CheckEligibilityRequestData>();
@@ -809,7 +826,7 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         await _fakeInMemoryDb.SaveChangesAsync();
         _moqEcsGateway.Setup(x => x.UseEcsforChecks).Returns("false");
         _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
-            .ReturnsAsync(CheckEligibilityStatus.error.ToString());
+            .ReturnsAsync(citizenResponse);
         var result = new StatusCodeResult(StatusCodes.Status500InternalServerError);
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>())).ReturnsAsync("");
 
@@ -876,6 +893,9 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
     public void Given_SurnameCharacterMatchFails_HMRC_Process_Should_Return_updatedStatus_parentNotFound()
     {
         // Arrange
+        CAPICitizenResponse citizenResponse = _fixture.Create<CAPICitizenResponse>();
+        citizenResponse.CheckEligibilityStatus = CheckEligibilityStatus.parentNotFound;
+
         var item = _fixture.Create<EligibilityCheck>();
         var fsm = _fixture.Create<CheckEligibilityRequestData>();
         item.Status = CheckEligibilityStatus.queuedForProcessing;
@@ -896,7 +916,7 @@ public class CheckEligibilityServiceTests : TestBase.TestBase
         _fakeInMemoryDb.SaveChangesAsync();
         _moqEcsGateway.Setup(x => x.UseEcsforChecks).Returns("false");
         _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
-            .ReturnsAsync(CheckEligibilityStatus.parentNotFound.ToString());
+            .ReturnsAsync(citizenResponse);
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>())).ReturnsAsync("");
 
         // Act

--- a/CheckYourEligibility.API/Boundary/Responses/CAPICitizenResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/CAPICitizenResponse.cs
@@ -1,0 +1,9 @@
+﻿using CheckYourEligibility.API.Domain.Enums;
+
+namespace CheckYourEligibility.API.Boundary.Responses
+{
+    public class CAPICitizenResponse: CAPIClaimResponse
+    {
+           public string? Guid { get; set; }
+    }
+}

--- a/CheckYourEligibility.API/Boundary/Responses/CAPIClaimResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/CAPIClaimResponse.cs
@@ -1,0 +1,13 @@
+﻿using CheckYourEligibility.API.Domain.Enums;
+using System.Net;
+
+namespace CheckYourEligibility.API.Boundary.Responses
+{
+    public class CAPIClaimResponse
+    {
+        public CheckEligibilityStatus? checkEligibilityStatus {  get; set; }  
+        public HttpStatusCode CAPIResponseCode { get; set; }
+        public string CAPIEndpoint { get; set; }
+        public string Reason { get; set; }
+    }
+}

--- a/CheckYourEligibility.API/Boundary/Responses/CAPIClaimResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/CAPIClaimResponse.cs
@@ -5,7 +5,7 @@ namespace CheckYourEligibility.API.Boundary.Responses
 {
     public class CAPIClaimResponse
     {
-        public CheckEligibilityStatus? checkEligibilityStatus {  get; set; }  
+        public CheckEligibilityStatus CheckEligibilityStatus {  get; set; }  
         public HttpStatusCode CAPIResponseCode { get; set; }
         public string CAPIEndpoint { get; set; }
         public string Reason { get; set; }

--- a/CheckYourEligibility.API/Domain/ECSConflicts.cs
+++ b/CheckYourEligibility.API/Domain/ECSConflicts.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 
 namespace CheckYourEligibility.API.Domain
 {
@@ -20,6 +21,10 @@ namespace CheckYourEligibility.API.Domain
        public DateTime TimeStamp { get; set; }
        public string EligibilityCheckHashID { get; set; }
        public virtual EligibilityCheckHash EligibilityCheckHash { get; set; }
-   
+       public HttpStatusCode CAPIResponseCode { get; set; }
+       public string CAPIEndpoint { get; set; }
+       public string Reason { get; set; }
+
+
     }
 }

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -921,8 +921,7 @@ public class CheckEligibilityGateway : BaseGateway, ICheckEligibility
         return convertEcsResultStatus(result);
     }
 
-
-    private async Task<CheckEligibilityStatus> DwpCitizenCheck(CheckProcessData data,
+    private async Task<CAPIClaimResponse> DwpCitizenCheck(CheckProcessData data,
         CheckEligibilityStatus checkResult, string correlationId)
     {
         var citizenRequest = new CitizenMatchRequest
@@ -945,11 +944,12 @@ public class CheckEligibilityGateway : BaseGateway, ICheckEligibility
         _logger.LogInformation($"Dwp before getting citizen");
 
         _logger.LogInformation(JsonConvert.SerializeObject(citizenRequest));
-        var guid = await _dwpGateway.GetCitizen(citizenRequest, data.Type, correlationId);
+        var citizenResponse = await _dwpGateway.GetCitizen(citizenRequest, data.Type, correlationId);
         _logger.LogInformation($"Dwp after getting citizen");
-        if (guid.Length != 64)
+
+        if (string.IsNullOrEmpty(citizenResponse.Guid))
         {
-            _logger.LogInformation($"Dwp after getting citizen error " + guid);
+            _logger.LogInformation($"Dwp after getting citizen error " + citizenResponse.checkEligibilityStatus );
             return (CheckEligibilityStatus)Enum.Parse(typeof(CheckEligibilityStatus), guid);
         }
 

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -16,6 +16,7 @@ using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -931,7 +932,7 @@ public class CheckEligibilityGateway : BaseGateway, ICheckEligibility
         return convertEcsResultStatus(result);
     }
 
-    private async Task<CAPIClaimResponse> DwpCitizenCheck(CheckProcessData data,
+    public async Task<CAPIClaimResponse> DwpCitizenCheck(CheckProcessData data,
         CheckEligibilityStatus checkResult, string correlationId)
     {
 
@@ -973,7 +974,6 @@ public class CheckEligibilityGateway : BaseGateway, ICheckEligibility
 
             // Perform a benefit check
             var result = await _dwpGateway.GetCitizenClaims(citizenResponse.Guid, DateTime.Now.AddMonths(-3).ToString("yyyy-MM-dd"),
-
             DateTime.Now.ToString("yyyy-MM-dd"), data.Type, correlationId);
             _logger.LogInformation($"Dwp after getting claim");
   
@@ -999,6 +999,7 @@ public class CheckEligibilityGateway : BaseGateway, ICheckEligibility
                $"v2/citizens/{citizenResponse.Guid}/claims?benefitType=pensions_credit,universal_credit,employment_support_allowance_income_based,income_support,job_seekers_allowance_income_based";
             claimResponse.CheckEligibilityStatus = checkResult;
             claimResponse.Reason = result.Item2; // reason message returned from DWP gateway
+            claimResponse.CAPIResponseCode = (HttpStatusCode)result.Item1.StatusCode;
         } 
         return claimResponse;
     }

--- a/CheckYourEligibility.API/Migrations/20251008170430_AddCAPIReasonFieldsToECSConflicts.Designer.cs
+++ b/CheckYourEligibility.API/Migrations/20251008170430_AddCAPIReasonFieldsToECSConflicts.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CheckYourEligibility.API.Migrations
 {
     [DbContext(typeof(EligibilityCheckContext))]
-    partial class EligibilityCheckContextModelSnapshot : ModelSnapshot
+    [Migration("20251008170430_AddCAPIReasonFieldsToECSConflicts")]
+    partial class AddCAPIReasonFieldsToECSConflicts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CheckYourEligibility.API/Migrations/20251008170430_AddCAPIReasonFieldsToECSConflicts.cs
+++ b/CheckYourEligibility.API/Migrations/20251008170430_AddCAPIReasonFieldsToECSConflicts.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CheckYourEligibility.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCAPIReasonFieldsToECSConflicts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CAPIEndpoint",
+                table: "ECSConflicts",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "CAPIResponseCode",
+                table: "ECSConflicts",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Reason",
+                table: "ECSConflicts",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CAPIEndpoint",
+                table: "ECSConflicts");
+
+            migrationBuilder.DropColumn(
+                name: "CAPIResponseCode",
+                table: "ECSConflicts");
+
+            migrationBuilder.DropColumn(
+                name: "Reason",
+                table: "ECSConflicts");
+        }
+    }
+}


### PR DESCRIPTION
Adding more data for recording for CAPI citizen endpoint.
Adding more columns in ECS conflict table - endpoint , reason, status code returned.

Adding new logic for CAPI reason response and capture in new columns …

Unit testing for DWP citizen checks.

https://dev.azure.com/dfe-gov-uk/Solutions%20Development/_boards/board/t/ECS/Stories?System.AssignedTo=Lili.NEDELEVA%40EDUCATION.GOV.UK&workitem=241824