### PR TITLE
ensure we pass the correct db context when ecs has conflict response

### DIFF
--- a/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
@@ -447,7 +447,7 @@ public class CheckingEngineGateway : ICheckingEngine
             // Create a record
             if (source == ProcessEligibilityCheckSource.ECS_CONFLICT)
             {
-                var organisation = await _db.Audits.FirstOrDefaultAsync(a => a.TypeID == guid);
+                var organisation = await context.Audits.FirstOrDefaultAsync(a => a.TypeID == guid);
                 ECSConflict ecsConflictRecord = new()
                 {
                     CorrelationID = correlationId,


### PR DESCRIPTION
ensure we pass the correct db context when ecs has conflict response