### PR TITLE
Elig 2824 httpclient polly policies

### DIFF
--- a/CheckYourEligibility.API.Tests/CheckYourEligibility.API.Tests.csproj
+++ b/CheckYourEligibility.API.Tests/CheckYourEligibility.API.Tests.csproj
@@ -15,8 +15,8 @@
         <PackageReference Include="AutoFixture" Version="4.18.1" />
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
         <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="NUnit" Version="4.1.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
@@ -45,8 +45,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <EmbeddedResource Include="Resources\HMRCManualEligibilityEvent.xlsm"/>
-        <EmbeddedResource Include="Resources\HMRCManualEligibilityEvent_invalid.xlsm"/>
+        <EmbeddedResource Include="Resources\HMRCManualEligibilityEvent.xlsm" />
+        <EmbeddedResource Include="Resources\HMRCManualEligibilityEvent_invalid.xlsm" />
     </ItemGroup>
 
 </Project>

--- a/CheckYourEligibility.API.Tests/HttpClientPolicies/HttpClientPoliciesTests.cs
+++ b/CheckYourEligibility.API.Tests/HttpClientPolicies/HttpClientPoliciesTests.cs
@@ -51,7 +51,6 @@ namespace CheckYourEligibility.API.Tests.HttpClientPolicies
         [Test]
         public async Task HttpClient_Retries_OnTaskCancellationError()
         {
-            // Arrange: Mock handler to fail twice, then succeed
             var handlerMock = new Mock<HttpMessageHandler>();
             int callCount = 0;
             handlerMock.Protected()

--- a/CheckYourEligibility.API.Tests/HttpClientPolicies/HttpClientPoliciesTests.cs
+++ b/CheckYourEligibility.API.Tests/HttpClientPolicies/HttpClientPoliciesTests.cs
@@ -82,7 +82,7 @@ namespace CheckYourEligibility.API.Tests.HttpClientPolicies
             var response = await client.GetAsync("http://test");
             // Assert
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-            Assert.That(4, Is.EqualTo(callCount)); // Should retry 3 times before succeedding
+            Assert.That(4, Is.EqualTo(callCount));
         }
 
         private static Exception CreateHttpClientTimeoutLikeException()

--- a/CheckYourEligibility.API.Tests/HttpClientPolicies/HttpClientPoliciesTests.cs
+++ b/CheckYourEligibility.API.Tests/HttpClientPolicies/HttpClientPoliciesTests.cs
@@ -1,0 +1,115 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using System.Net.Sockets;
+
+namespace CheckYourEligibility.API.Tests.HttpClientPolicies
+{
+    public class HttpClientPoliciesTests
+
+    {
+
+        [Test]
+        public async Task HttpClient_Retries_OnTransientFailure()
+        {
+            // Arrange: Mock handler to fail twice, then succeed
+            var handlerMock = new Mock<HttpMessageHandler>();
+            int callCount = 0;
+            handlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() =>
+                {
+                    callCount++;
+                    if (callCount < 4)
+                    {
+                        throw new HttpRequestException();
+                    }
+                        return new HttpResponseMessage(HttpStatusCode.OK);
+                });
+
+            var services = new ServiceCollection();
+            services.AddHttpClient("Dwp")
+                .ConfigurePrimaryHttpMessageHandler(() => handlerMock.Object)
+                .AddPolicyHandler(API.HttpClientPolicies.GetRetryPolicyWithJitter())
+                .AddPolicyHandler(API.HttpClientPolicies.GetCircuitBreakerPolicy());
+
+            var provider = services.BuildServiceProvider();
+            var clientFactory = provider.GetRequiredService<IHttpClientFactory>();
+            var client = clientFactory.CreateClient("Dwp");
+
+            // Act
+            var response = await client.GetAsync("http://test");
+
+            // Assert
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(4,  Is.EqualTo(callCount));
+        }
+        [Test]
+        public async Task HttpClient_Retries_OnTaskCancellationError()
+        {
+            // Arrange: Mock handler to fail twice, then succeed
+            var handlerMock = new Mock<HttpMessageHandler>();
+            int callCount = 0;
+            handlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() =>
+                {
+                    callCount++;
+                    if (callCount < 4)
+                    {
+                        throw CreateHttpClientTimeoutLikeException();
+                    }
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                });
+
+            var services = new ServiceCollection();
+            services.AddHttpClient("Dwp")
+                .ConfigurePrimaryHttpMessageHandler(() => handlerMock.Object)
+                .AddPolicyHandler(API.HttpClientPolicies.GetRetryPolicyWithJitter())
+                .AddPolicyHandler(API.HttpClientPolicies.GetCircuitBreakerPolicy());
+
+            var provider = services.BuildServiceProvider();
+            var clientFactory = provider.GetRequiredService<IHttpClientFactory>();
+            var client = clientFactory.CreateClient("Dwp");
+
+            // Act
+            var response = await client.GetAsync("http://test");
+            // Assert
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(4, Is.EqualTo(callCount)); // Should retry 3 times before succeedding
+        }
+
+        private static Exception CreateHttpClientTimeoutLikeException()
+{
+    // Inner
+    var socket = new SocketException((int)SocketError.OperationAborted);
+
+    // Wrapped in
+    var io = new IOException(
+        "Unable to read data from the transport connection: " +
+        "The I/O operation has been aborted because of either a thread exit or an application request.",
+        socket);
+
+    var innerTce = new TaskCanceledException("The operation was canceled.");
+
+    var timeout = new TimeoutException("The operation was canceled.", io);
+
+    // Top-level: HttpClient throws TaskCanceledException on timeout
+    return new TaskCanceledException(
+        "The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing. " +
+        "The operation was canceled. The operation was canceled. " +
+        "Unable to read data from the transport connection: " +
+        "The I/O operation has been aborted because of either a thread exit or an application request.. " +
+        "The I/O operation has been aborted because of either a thread exit or an application request.",
+        timeout);
+}
+
+    }
+}

--- a/CheckYourEligibility.API/Adapters/DwpAdapter.cs
+++ b/CheckYourEligibility.API/Adapters/DwpAdapter.cs
@@ -307,7 +307,6 @@ public class DwpAdapter: IDwpAdapter
             // ECS_Conflict helper logic to better track conflicts
             citizenResponse.CAPIResponseCode = response.StatusCode;
           
-
             if (response.IsSuccessStatusCode)
             {
                 var responseData =

--- a/CheckYourEligibility.API/CheckYourEligibility.API.csproj
+++ b/CheckYourEligibility.API/CheckYourEligibility.API.csproj
@@ -41,8 +41,11 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="open-xml-sdk" Version="2.9.1" />
+        <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="6.1.0" />
         <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />

--- a/CheckYourEligibility.API/HttpClientPolicies.cs
+++ b/CheckYourEligibility.API/HttpClientPolicies.cs
@@ -1,0 +1,47 @@
+﻿using Polly;
+using Polly.Contrib.WaitAndRetry;
+using Polly.Extensions.Http;
+
+namespace CheckYourEligibility.API
+{
+    public static class HttpClientPolicies
+    {
+
+        /// <summary>
+        ///  Define Polly's policy for Http Retries with jitter.
+        /// </summary>
+        /// <param name="retryCount">How many times a single request will be retried before giving up</param>
+        /// <returns></returns>
+        public  static IAsyncPolicy<HttpResponseMessage> GetRetryPolicyWithJitter()
+        {
+            var delay = Backoff.DecorrelatedJitterBackoffV2(medianFirstRetryDelay: TimeSpan.FromSeconds(2), retryCount: 3);
+
+            return HttpPolicyExtensions
+                .HandleTransientHttpError() //(e.g., a momentary 5xx, a brief network hiccup).
+                .Or<TaskCanceledException>() // to handle HttpClient.Timeout
+                .WaitAndRetryAsync(delay);
+        }
+
+        /// <summary>
+        /// Define a cicruit breaker policy
+        /// Circuit breaks when 10% of calls 
+        /// failsamplingDuration: 30s Looks at request outcomes over the last 30 seconds minimumThroughput: 100
+        /// Needs at least 100 calls in the sampling window to make a decision 
+        /// durationOfBreak: 5s When broken, stays open (fails fast) for 5 seconds
+        /// </summary>
+        /// <returns></returns>
+        public static IAsyncPolicy<HttpResponseMessage> GetCircuitBreakerPolicy()
+        {
+            
+            return HttpPolicyExtensions
+                .HandleTransientHttpError() //(e.g., a momentary 5xx, a brief network hiccup).
+                .AdvancedCircuitBreakerAsync(
+                failureThreshold: 0.1,
+                samplingDuration:TimeSpan.FromSeconds(30),
+                minimumThroughput:100,
+                durationOfBreak: TimeSpan.FromSeconds(5));
+        }
+       public static IAsyncPolicy<HttpResponseMessage> GetTimeoutPolicy(int timeOut) =>
+            Policy.TimeoutAsync<HttpResponseMessage>(timeOut);
+    }
+}

--- a/CheckYourEligibility.API/HttpClientPolicies.cs
+++ b/CheckYourEligibility.API/HttpClientPolicies.cs
@@ -41,7 +41,5 @@ namespace CheckYourEligibility.API
                 minimumThroughput:100,
                 durationOfBreak: TimeSpan.FromSeconds(5));
         }
-       public static IAsyncPolicy<HttpResponseMessage> GetTimeoutPolicy(int timeOut) =>
-            Policy.TimeoutAsync<HttpResponseMessage>(timeOut);
     }
 }

--- a/CheckYourEligibility.API/ProgramExtensions.cs
+++ b/CheckYourEligibility.API/ProgramExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Text;
-using CheckYourEligibility.API.Adapters;
+﻿using CheckYourEligibility.API.Adapters;
 using CheckYourEligibility.API.Domain;
 using CheckYourEligibility.API.Domain.Constants;
 using CheckYourEligibility.API.Extensions;
@@ -11,7 +9,8 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Azure;
 using Microsoft.IdentityModel.Tokens;
-
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
 namespace CheckYourEligibility.API;
 
 [ExcludeFromCodeCoverage(Justification = "extension of program")]
@@ -32,9 +31,7 @@ public static class ProgramExtensions
                 x => x.MigrationsAssembly("CheckYourEligibility.API"))
 
         );
-      
-
-
+     
         return services;
     }
 
@@ -67,13 +64,18 @@ public static class ProgramExtensions
         return services;
     }
 
+
     public static IServiceCollection AddExternalServices(this IServiceCollection services, IConfiguration configuration)
     {
+
+
         // Register HttpClient normally
         services.AddHttpClient("Dwp", client =>
         {
             client.BaseAddress = new Uri(configuration["Dwp:BaseUrl"]);
-        });
+        })
+          .AddPolicyHandler(HttpClientPolicies.GetRetryPolicyWithJitter())
+          .AddPolicyHandler(HttpClientPolicies.GetCircuitBreakerPolicy());
 
         // Register DwpAdapter as singleton, inject IHttpClientFactory
         services.AddSingleton<IDwpAdapter>(sp =>
@@ -93,8 +95,11 @@ public static class ProgramExtensions
             {
                 client.BaseAddress = new Uri(ecsBaseUrl);
                 client.Timeout = TimeSpan.FromSeconds(30);
-            });
-
+               
+            })
+            .AddPolicyHandler(HttpClientPolicies.GetRetryPolicyWithJitter())
+            .AddPolicyHandler(HttpClientPolicies.GetCircuitBreakerPolicy());
+            
             services.AddSingleton<IEcsEligibilityEventsAdapter>(sp =>
             {
                 var logger = sp.GetRequiredService<ILogger<EcsEligibilityEventsAdapter>>();

--- a/CheckYourEligibility.API/Usecases/ProcessEligibilityBulkCheckUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ProcessEligibilityBulkCheckUseCase.cs
@@ -107,7 +107,6 @@ public class ProcessEligibilityBulkCheckUseCase : IProcessEligibilityBulkCheckUs
 
                         }
 
-
                     }
 
                     catch (Exception ex)


### PR DESCRIPTION
1. Add retry http client polly policy with jitter
2. Add circuit breaker polly policy
3. 2 unit tests to simulate the behaviour seen in prod
source :
https://learn.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/implement-circuit-breaker-pattern
used the defaults for the circuit breaker : https://devblogs.microsoft.com/dotnet/circuit-breaker-policy-finetuning-best-practice/
jitter: https://devblogs.microsoft.com/dotnet/circuit-breaker-policy-finetuning-best-practice/

Average exceptions per second: 
<img width="430" height="260" alt="image" src="https://github.com/user-attachments/assets/cec2139a-2397-4f1f-89a3-4b5cad001c36" />
