### PR TITLE
Allow NULL in PartnerFirstName and PartnerLastName fields

### DIFF
--- a/CheckYourEligibility.API/Domain/WorkingFamiliesEvent.cs
+++ b/CheckYourEligibility.API/Domain/WorkingFamiliesEvent.cs
@@ -25,9 +25,9 @@ public class WorkingFamiliesEvent
 
     public DateTime? PartnerDateOfBirth { get; set; }
 
-    [Column(TypeName = "varchar(100)")] public string PartnerFirstName { get; set; }
+    [Column(TypeName = "varchar(100)")] public string? PartnerFirstName { get; set; }
 
-    [Column(TypeName = "varchar(100)")] public string PartnerLastName { get; set; }
+    [Column(TypeName = "varchar(100)")] public string? PartnerLastName { get; set; }
 
     [Column(TypeName = "varchar(10)")] public string? PartnerNationalInsuranceNumber { get; set; }
     public DateTime SubmissionDate { get; set; }

--- a/CheckYourEligibility.API/Migrations/20260324171807_AllowNullsForWorkingFamiliesEventsPartnerFields.Designer.cs
+++ b/CheckYourEligibility.API/Migrations/20260324171807_AllowNullsForWorkingFamiliesEventsPartnerFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CheckYourEligibility.API.Migrations
 {
     [DbContext(typeof(EligibilityCheckContext))]
-    partial class EligibilityCheckContextModelSnapshot : ModelSnapshot
+    [Migration("20260324171807_AllowNullsForWorkingFamiliesEventsPartnerFields")]
+    partial class AllowNullsForWorkingFamiliesEventsPartnerFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CheckYourEligibility.API/Migrations/20260324171807_AllowNullsForWorkingFamiliesEventsPartnerFields.cs
+++ b/CheckYourEligibility.API/Migrations/20260324171807_AllowNullsForWorkingFamiliesEventsPartnerFields.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CheckYourEligibility.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AllowNullsForWorkingFamiliesEventsPartnerFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "PartnerLastName",
+                table: "WorkingFamiliesEvents",
+                type: "varchar(100)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PartnerFirstName",
+                table: "WorkingFamiliesEvents",
+                type: "varchar(100)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "PartnerLastName",
+                table: "WorkingFamiliesEvents",
+                type: "varchar(100)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PartnerFirstName",
+                table: "WorkingFamiliesEvents",
+                type: "varchar(100)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
Update WorkingFamiliesEvents table to allow NULL values in the PartnerFirstName and PartnerLastName fields, as partner data is not a required element.