### PR TITLE
Elig 2794 fix clear text storage of sensitive information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,3 +405,4 @@ tests/cypress.env.json
 /CheckYourEligibility.API/Properties/serviceDependencies.local.json
 /CheckYourEligibility.AcceptanceTests/acceptance.runsettings
 /CheckYourEligibility.API/appsettings - Copy.Development.json
+/tests/audit.txt

--- a/CheckYourEligibility.API/Adapters/EcsAdapter.cs
+++ b/CheckYourEligibility.API/Adapters/EcsAdapter.cs
@@ -143,8 +143,7 @@ public class EcsAdapter : IEcsAdapter
             soapMessage = soapMessage.Replace("<ns:EligibilityCheckType>FSM</ns:EligibilityCheckType>",
                 $"<ns:EligibilityCheckType>EYPP</ns:EligibilityCheckType>");
         }
-        string logSoapMessage = soapMessage.Replace(EcsPassword, "RemovedFromLogs");
-        _logger.LogInformation($"ECS soap message generated: {logSoapMessage}");
+        _logger.LogInformation("ECS SOAP request generated for eligibility check type {CheckType}.", eligibilityType);
         return await executeEcsCheck(soapMessage);
     }
 


### PR DESCRIPTION
## ELIG-2794

Removed logging of ECS SOAP request payloads from `EcsAdapter`.

### Changes
- Removed logging of SOAP request body in `EcsCheck`
- Replaced with a non-sensitive informational log entry
- Corrected log to use actual `eligibilityType` instead of a hard-coded value

### Reason
The SOAP payload contains sensitive information (credentials and personal data). Even after masking the password, the logged value was still derived from the original sensitive string, which caused CodeQL to flag it as clear text storage of sensitive information.

### Outcome
No sensitive ECS request data is written to logs. CodeQL alert addressed.
https://dfedigital.atlassian.net/browse/ELIG-2794