### PR TITLE
FixClear text storage of sensitive information for EcsWFCheck

### DIFF
--- a/CheckYourEligibility.API/Adapters/EcsAdapter.cs
+++ b/CheckYourEligibility.API/Adapters/EcsAdapter.cs
@@ -165,8 +165,7 @@ public class EcsAdapter : IEcsAdapter
             soapMessage = soapMessage.Replace("<ns:Surname/>",
                 $"<ns:Surname>{eligibilityCheck.LastName}</ns:Surname>");
         }
-        string logSoapMessage = soapMessage.Replace(EcsPassword, "RemovedFromLogs");
-        _logger.LogInformation($"ECS soap message generated: {logSoapMessage}");
+        _logger.LogInformation("ECS SOAP request generated for warm flag check.");
         return await executeEcsCheck(soapMessage);
     }
 }


### PR DESCRIPTION
## ELIG-2795

Removed logging of ECS warm flag SOAP request payloads from `EcsAdapter`.

### Changes
- Removed logging of the SOAP request body in `EcsWFCheck`
- Replaced it with a non-sensitive informational log entry

### Reason
The SOAP payload contains sensitive information, including credentials and personal data. Even though the password was being replaced before logging, the logged value was still derived from the original sensitive string, which caused CodeQL to flag it as clear text storage of sensitive information.

### Outcome
No sensitive ECS warm flag request data is written to logs. CodeQL alert addressed.

https://dfedigital.atlassian.net/browse/ELIG-2795