### PR TITLE
ELIG0-2796 FixMissing X-Frame-Options HTTP header

### DIFF
--- a/CheckYourEligibility.API/web.config
+++ b/CheckYourEligibility.API/web.config
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <configuration>
-	<system.webServer>
-		<httpProtocol>
-			<customHeaders>
-				<add name="X-Frame-Options" value="DENY" />
-			</customHeaders>
-		</httpProtocol>
-	</system.webServer>
-
 	<location path="." inheritInChildApplications="false">
 		<system.webServer>
 			<handlers>
@@ -24,6 +16,7 @@
 			<httpProtocol>
 				<customHeaders>
 					<remove name="X-Powered-By" />
+                    <add name="X-Frame-Options" value="DENY" />
 				</customHeaders>
 			</httpProtocol>
 		</system.webServer>

--- a/CheckYourEligibility.API/web.config
+++ b/CheckYourEligibility.API/web.config
@@ -1,26 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <configuration>
-    <location path="." inheritInChildApplications="false">
-        <system.webServer>
-            <handlers>
-                <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
-            </handlers>
-            <aspNetCore processPath="dotnet" arguments=".\CheckYourEligibility.API.dll" stdoutLogEnabled="false"
+	<system.webServer>
+		<httpProtocol>
+			<customHeaders>
+				<add name="X-Frame-Options" value="DENY" />
+			</customHeaders>
+		</httpProtocol>
+	</system.webServer>
+
+	<location path="." inheritInChildApplications="false">
+		<system.webServer>
+			<handlers>
+				<add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+			</handlers>
+			<aspNetCore processPath="dotnet" arguments=".\CheckYourEligibility.API.dll" stdoutLogEnabled="false"
                         stdoutLogFile="\\?\%home%\LogFiles\stdout" hostingModel="inprocess" />
-            <security>
-                <requestFiltering removeServerHeader="true">
-                    <requestLimits maxAllowedContentLength="1073741824" />
-                </requestFiltering>
-            </security>
-            <httpProtocol>
-                <customHeaders>
-                    <remove name="X-Powered-By" />
-                </customHeaders>
-            </httpProtocol>
-        </system.webServer>
-    </location>
-    <system.web>
-        <httpRuntime maxRequestLength="1048576" />
-    </system.web>
+			<security>
+				<requestFiltering removeServerHeader="true">
+					<requestLimits maxAllowedContentLength="1073741824" />
+				</requestFiltering>
+			</security>
+			<httpProtocol>
+				<customHeaders>
+					<remove name="X-Powered-By" />
+				</customHeaders>
+			</httpProtocol>
+		</system.webServer>
+	</location>
+	<system.web>
+		<httpRuntime maxRequestLength="1048576" />
+	</system.web>
 </configuration>


### PR DESCRIPTION
Investigation

CodeQL flagged a high severity vulnerability (cs/web/missing-x-frame-options) in CheckYourEligibility.API/web.config.

The application configuration did not expose the X-Frame-Options header in a location that CodeQL recognises as global protection. As a result, the site could still be treated as vulnerable to clickjacking.

Fix
Updated CheckYourEligibility.API/web.config
Added the X-Frame-Options response header at the root system.webServer > httpProtocol > customHeaders level
Set the value to DENY

Outcome

The application now returns the X-Frame-Options: DENY header from a global configuration location, reducing exposure to clickjacking and resolving the CodeQL alert.

https://dfedigital.atlassian.net/browse/ELIG-2796