### PR TITLE
ELIG-2949-ELIG-2945-AC2-Expose-MAT-membership-for-establishments-API-support-for-dashboard-tile-logic

### DIFF
--- a/CheckYourEligibility.API.Tests/Controllers/EstablishmentControllerTests.cs
+++ b/CheckYourEligibility.API.Tests/Controllers/EstablishmentControllerTests.cs
@@ -15,6 +15,7 @@ public class EstablishmentControllerTests : TestBase.TestBase
 {
     private Fixture _fixture;
     private Mock<IAudit> _mockAuditGateway;
+    private Mock<IApplication> _mockApplicationGateway;
     private ILogger<EstablishmentController> _mockLogger;
     private Mock<ISearchEstablishmentsUseCase> _mockSearchUseCase;
     private EstablishmentController _sut;
@@ -25,7 +26,12 @@ public class EstablishmentControllerTests : TestBase.TestBase
         _mockSearchUseCase = new Mock<ISearchEstablishmentsUseCase>(MockBehavior.Strict);
         _mockLogger = Mock.Of<ILogger<EstablishmentController>>();
         _mockAuditGateway = new Mock<IAudit>(MockBehavior.Strict);
-        _sut = new EstablishmentController(_mockLogger, _mockSearchUseCase.Object, _mockAuditGateway.Object);
+        _mockApplicationGateway = new Mock<IApplication>(MockBehavior.Strict);
+        _sut = new EstablishmentController(
+            _mockLogger,
+            _mockSearchUseCase.Object,
+            _mockAuditGateway.Object,
+            _mockApplicationGateway.Object);
         _fixture = new Fixture();
     }
 

--- a/CheckYourEligibility.API.Tests/Controllers/EstablishmentControllerTests.cs
+++ b/CheckYourEligibility.API.Tests/Controllers/EstablishmentControllerTests.cs
@@ -39,6 +39,7 @@ public class EstablishmentControllerTests : TestBase.TestBase
     public void Teardown()
     {
         _mockSearchUseCase.VerifyAll();
+        _mockApplicationGateway.VerifyAll();
     }
 
     [Test]

--- a/CheckYourEligibility.API.Tests/Controllers/EstablishmentControllerTests.cs
+++ b/CheckYourEligibility.API.Tests/Controllers/EstablishmentControllerTests.cs
@@ -96,4 +96,40 @@ public class EstablishmentControllerTests : TestBase.TestBase
         // Assert
         response.Should().BeEquivalentTo(expectedResult);
     }
+
+    [Test]
+    public async Task Given_GetMultiAcademyTrustId_Should_Return_Status200OK()
+    {
+        // Arrange
+        var establishmentId = _fixture.Create<int>();
+        var matId = _fixture.Create<int>();
+
+        _mockApplicationGateway
+            .Setup(x => x.GetMultiAcademyTrustIdForEstablishment(establishmentId))
+            .ReturnsAsync(matId);
+
+        var expectedResult = new ObjectResult(matId)
+        {
+            StatusCode = StatusCodes.Status200OK
+        };
+
+        // Act
+        var response = await _sut.GetMultiAcademyTrustIdForEstablishment(establishmentId);
+
+        // Assert
+        response.Should().BeEquivalentTo(expectedResult);
+    }
+
+    [Test]
+    public async Task Given_GetMultiAcademyTrustId_With_Invalid_Id_Should_Return_Status400BadRequest()
+    {
+        // Arrange
+        var establishmentId = 0;
+
+        // Act
+        var response = await _sut.GetMultiAcademyTrustIdForEstablishment(establishmentId);
+
+        // Assert
+        response.Should().BeOfType<BadRequestObjectResult>();
+    }
 }

--- a/CheckYourEligibility.API/Controllers/EstablishmentController.cs
+++ b/CheckYourEligibility.API/Controllers/EstablishmentController.cs
@@ -15,15 +15,18 @@ public class EstablishmentController : BaseController
 {
     private readonly ILogger<EstablishmentController> _logger;
     private readonly ISearchEstablishmentsUseCase _searchUseCase;
+    private readonly IApplication _applicationGateway;
 
     public EstablishmentController(
-        ILogger<EstablishmentController> logger,
-        ISearchEstablishmentsUseCase searchUseCase,
-        IAudit audit)
-        : base(audit)
+    ILogger<EstablishmentController> logger,
+    ISearchEstablishmentsUseCase searchUseCase,
+    IAudit audit,
+    IApplication applicationGateway)
+    : base(audit)
     {
         _logger = logger;
         _searchUseCase = searchUseCase;
+        _applicationGateway = applicationGateway;
     }
 
     [ProducesResponseType(typeof(IEnumerable<Establishment>), (int)HttpStatusCode.OK)]

--- a/CheckYourEligibility.API/Controllers/EstablishmentController.cs
+++ b/CheckYourEligibility.API/Controllers/EstablishmentController.cs
@@ -45,4 +45,32 @@ public class EstablishmentController : BaseController
         return new ObjectResult(new EstablishmentSearchResponse { Data = results })
             { StatusCode = StatusCodes.Status200OK };
     }
+
+    /// <summary>
+    /// Gets the multi academy trust ID for a given establishment
+    /// </summary>
+    /// <param name="establishmentId">Establishment ID</param>
+    /// <returns>Multi academy trust ID, or 0 if the establishment is not part of a MAT</returns>
+    [ProducesResponseType(typeof(int), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ErrorResponse), (int)HttpStatusCode.BadRequest)]
+    [Consumes("application/json", "application/vnd.api+json;version=1.0")]
+    [HttpGet("/establishment/{establishmentId}/multi-academy-trust-id")]
+    [Authorize(Policy = PolicyNames.RequireLaOrMatOrSchoolScope)]
+    public async Task<ActionResult> GetMultiAcademyTrustIdForEstablishment(int establishmentId)
+    {
+        if (establishmentId <= 0)
+        {
+            return BadRequest(new ErrorResponse
+            {
+                Errors = [new Error { Title = "A valid establishmentId is required." }]
+            });
+        }
+
+        var matId = await _applicationGateway.GetMultiAcademyTrustIdForEstablishment(establishmentId);
+
+        return new ObjectResult(matId)
+        {
+            StatusCode = StatusCodes.Status200OK
+        };
+    }
 }


### PR DESCRIPTION
Adds API support for determining MAT membership of establishments.

- New endpoint: GET /establishment/{establishmentId}/multi-academy-trust-id
- Uses existing IApplication.GetMultiAcademyTrustIdForEstablishment
- Returns MAT ID (int), or 0 if not in a MAT
- Includes validation and unit tests

Required for AC2 (dashboard tile logic) in frontend ticket 2945.