### PR TITLE
Elig 2870 batch check issues gateway timeout

### DIFF
--- a/CheckYourEligibility.API.Tests/Usecases/CheckEligibilityBulkUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/CheckEligibilityBulkUseCaseTests.cs
@@ -8,6 +8,7 @@ using CheckYourEligibility.API.UseCases;
 using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -24,12 +25,19 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
         _mockBulkCheckGateway = new Mock<IBulkCheck>(MockBehavior.Strict);
         _mockAuditGateway = new Mock<IAudit>(MockBehavior.Strict);
         _mockLogger = new Mock<ILogger<CheckEligibilityBulkUseCase>>(MockBehavior.Loose);
+        _mockScopeFactory = new Mock<IServiceScopeFactory>();
+        var mockScope = new Mock<IServiceScope>();
+        var mockServiceProvider = new Mock<IServiceProvider>();
+        mockServiceProvider.Setup(sp => sp.GetService(typeof(ICheckEligibility))).Returns(_mockCheckGateway.Object);
+        mockScope.Setup(s => s.ServiceProvider).Returns(mockServiceProvider.Object);
+        _mockScopeFactory.Setup(f => f.CreateScope()).Returns(mockScope.Object);
         _sut = new CheckEligibilityBulkUseCase(
             _mockValidator.Object,
             _mockCheckGateway.Object,
             _mockBulkCheckGateway.Object,
             _mockAuditGateway.Object,
-            _mockLogger.Object);
+            _mockLogger.Object,
+            _mockScopeFactory.Object);
         _recordCountLimit = 100;
     }
 
@@ -46,6 +54,7 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
     private Mock<IBulkCheck> _mockBulkCheckGateway;
     private Mock<IAudit> _mockAuditGateway;
     private Mock<ILogger<CheckEligibilityBulkUseCase>> _mockLogger;
+    private Mock<IServiceScopeFactory> _mockScopeFactory;
     private CheckEligibilityBulkUseCase _sut;
     private int _recordCountLimit;
 
@@ -126,8 +135,10 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
 
         _mockBulkCheckGateway.Setup(s => s.CreateBulkCheck(It.IsAny<BulkCheck>()))
             .ReturnsAsync(_fixture.Create<string>());
+        var postCheckCalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         _mockCheckGateway.Setup(s =>
                 s.PostCheck(It.IsAny<IEnumerable<IEligibilityServiceType>>(), It.IsAny<string>(), meta))
+            .Callback(() => postCheckCalled.SetResult(true))
             .Returns(Task.CompletedTask);
         _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.BulkCheck, It.IsAny<string>(), null))
             .ReturnsAsync(_fixture.Create<string>());
@@ -135,6 +146,7 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
 
         // Act
         var result = await _sut.Execute(model, CheckEligibilityType.WorkingFamilies, _recordCountLimit, meta);
+        await postCheckCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         // Assert
         result.Data.Status.Should().Be(Messages.Processing);
@@ -169,8 +181,10 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
 
         _mockBulkCheckGateway.Setup(s => s.CreateBulkCheck(It.IsAny<BulkCheck>()))
             .ReturnsAsync(_fixture.Create<string>());
+        var postCheckCalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         _mockCheckGateway.Setup(s =>
                 s.PostCheck(It.IsAny<IEnumerable<IEligibilityServiceType>>(), It.IsAny<string>(), meta))
+            .Callback(() => postCheckCalled.SetResult(true))
             .Returns(Task.CompletedTask);
         _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.BulkCheck, It.IsAny<string>(), null))
             .ReturnsAsync(_fixture.Create<string>());
@@ -178,6 +192,7 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
 
         // Act
         var result = await _sut.Execute(model, CheckEligibilityType.FreeSchoolMeals, _recordCountLimit, meta);
+        await postCheckCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         // Assert
         result.Data.Status.Should().Be(Messages.Processing);
@@ -214,19 +229,22 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
 
         _mockBulkCheckGateway.Setup(s => s.CreateBulkCheck(It.IsAny<BulkCheck>()))
             .ReturnsAsync(_fixture.Create<string>());
-        _mockCheckGateway.Setup(s => s.PostCheck(It.Is<IEnumerable<CheckEligibilityRequestData>>(
-                d => d.First().NationalInsuranceNumber == nino.ToUpper()), It.IsAny<string>(), meta))
+        var postCheckCalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _mockCheckGateway.Setup(s => s.PostCheck(It.Is<IEnumerable<IEligibilityServiceType>>(
+                d => ((CheckEligibilityRequestData)d.First()).NationalInsuranceNumber == nino.ToUpper()), It.IsAny<string>(), meta))
+            .Callback(() => postCheckCalled.SetResult(true))
             .Returns(Task.CompletedTask);
         _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.BulkCheck, It.IsAny<string>(), null))
             .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         await _sut.Execute(model, CheckEligibilityType.FreeSchoolMeals, _recordCountLimit, meta);
+        await postCheckCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         // Assert
         _mockBulkCheckGateway.Verify(s => s.CreateBulkCheck(It.IsAny<BulkCheck>()), Times.Once);
-        _mockCheckGateway.Verify(s => s.PostCheck(It.Is<IEnumerable<CheckEligibilityRequestData>>(
-            d => d.First().NationalInsuranceNumber == "AB123456C"), It.IsAny<string>(), meta), Times.Once);
+        _mockCheckGateway.Verify(s => s.PostCheck(It.Is<IEnumerable<IEligibilityServiceType>>(
+            d => ((CheckEligibilityRequestData)d.First()).NationalInsuranceNumber == "AB123456C"), It.IsAny<string>(), meta), Times.Once);
     }
 
     [Test]
@@ -280,13 +298,16 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
         _mockBulkCheckGateway.Setup(s => s.CreateBulkCheck(It.IsAny<BulkCheck>()))
             .Callback<BulkCheck>(b => capturedBulkCheck = b)
             .ReturnsAsync("bulk-check-id");
+        var postCheckCalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         _mockCheckGateway.Setup(s => s.PostCheck(It.IsAny<IEnumerable<IEligibilityServiceType>>(), It.IsAny<string>(), meta))
+            .Callback(() => postCheckCalled.SetResult(true))
             .Returns(Task.CompletedTask);
         _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.BulkCheck, It.IsAny<string>(), null))
             .ReturnsAsync("audit-id");
 
         // Act
         await _sut.Execute(model, CheckEligibilityType.FreeSchoolMeals, _recordCountLimit, meta);
+        await postCheckCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         // Assert
         capturedBulkCheck.Should().NotBeNull();

--- a/CheckYourEligibility.API/Boundary/Responses/CheckEligibilityItemResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/CheckEligibilityItemResponse.cs
@@ -14,6 +14,7 @@ public class CheckEligibilityItemBase
 [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
 public class CheckEligibilityItem : CheckEligibilityItemBase
 {
+    public string? EligibilityCheckID { get; set; }
     public string LastName { get; set; }
 
     public string DateOfBirth { get; set; }

--- a/CheckYourEligibility.API/Factories/MappingProfile.cs
+++ b/CheckYourEligibility.API/Factories/MappingProfile.cs
@@ -18,6 +18,7 @@ public class MappingProfile : Profile
         CreateMap<IEligibilityServiceType, EligibilityCheck>()
             .ReverseMap();
         CreateMap<EligibilityCheck, CheckEligibilityItem>()
+            .ForMember(dest => dest.EligibilityCheckID, opt => opt.Ignore())
             .ReverseMap();
         CreateMap<ApplicationRequestData, Application>()
             .ForMember(dest => dest.ParentNationalInsuranceNumber,

--- a/CheckYourEligibility.API/Gateways/AdministrationGateway.cs
+++ b/CheckYourEligibility.API/Gateways/AdministrationGateway.cs
@@ -1,12 +1,11 @@
 ﻿// Ignore Spelling: Fsm
 
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using CheckYourEligibility.API.Domain;
 using CheckYourEligibility.API.Domain.Enums;
 using CheckYourEligibility.API.Gateways.CsvImport;
 using CheckYourEligibility.API.Gateways.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CheckYourEligibility.API.Gateways;
 

--- a/CheckYourEligibility.API/Gateways/BulkCheckGateway.cs
+++ b/CheckYourEligibility.API/Gateways/BulkCheckGateway.cs
@@ -101,6 +101,19 @@ public class BulkCheckGateway : IBulkCheck
                 Total = results.Sum(s => s.ct),
                 Complete = results.Where(a => a.Status != CheckEligibilityStatus.queuedForProcessing).Sum(s => s.ct)
             };
+
+        // EligibilityCheck rows are inserted asynchronously after the BulkCheck record
+        // is created. If none exist yet, fall back to the BulkChecks table so that
+        // progress returns "0 of N complete" rather than 404.
+        var bulkCheck = await _db.BulkChecks
+            .FirstOrDefaultAsync(x => x.BulkCheckID == guid);
+        if (bulkCheck != null)
+            return new BulkStatus
+            {
+                Total = bulkCheck.NumberOfRecords,
+                Complete = 0
+            };
+
         return null;
     }
 

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -140,12 +140,6 @@ public class CheckEligibilityGateway : ICheckEligibility
                     }
                 }
             }
-            if (checkHashResult == null)
-            {
-                // Queue message will be sent by the caller (PostCheck bulk) after BulkInsert,
-                // or directly here for single checks.
-            }
-
             return item;
         }
         catch (Exception ex)

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -1,6 +1,7 @@
 ﻿// Ignore Spelling: Fsm
 
 using AutoMapper;
+using Azure.Storage.Queues;
 using CheckYourEligibility.API.Boundary.Requests;
 using CheckYourEligibility.API.Boundary.Responses;
 using CheckYourEligibility.API.Domain;
@@ -51,9 +52,16 @@ public class CheckEligibilityGateway : ICheckEligibility
         _db.BulkInsert_EligibilityCheck(mappedBulkedChecks);
 
         // Now send queue messages for records that weren't resolved from the hash cache.
-        foreach (var item in mappedBulkedChecks.Where(x => x.Status == CheckEligibilityStatus.queuedForProcessing))
+        // Reuse a single QueueClient for all bulk messages — they share the same queue.
+        var queuedBulkItems = mappedBulkedChecks.Where(x => x.Status == CheckEligibilityStatus.queuedForProcessing).ToList();
+        if (queuedBulkItems.Any())
         {
-            await _storageQueueMessageGateway.SendMessage(item);
+            var bulkQueueName = _configuration[$"Queue:Bulk:{queuedBulkItems.First().Type}"];
+            var bulkQueueClient = _storageQueueMessageGateway.GetQueueClient(bulkQueueName);
+            foreach (var item in queuedBulkItems)
+            {
+                await _storageQueueMessageGateway.SendMessage(item, bulkQueueClient);
+            }
         }
     }
     public async Task<PostCheckResult> PostCheck<T>(T data, CheckMetaData meta) where T : IEligibilityServiceType {
@@ -65,7 +73,9 @@ public class CheckEligibilityGateway : ICheckEligibility
         // Send queue message after the row is committed to the DB.
         if (item.Status == CheckEligibilityStatus.queuedForProcessing)
         {
-            await _storageQueueMessageGateway.SendMessage(item);
+            var singleQueueName = _configuration[$"Queue:Single:{item.Type}"];
+            var singleQueueClient = _storageQueueMessageGateway.GetQueueClient(singleQueueName);
+            await _storageQueueMessageGateway.SendMessage(item, singleQueueClient);
         }
 
         return new PostCheckResult { Id = item.EligibilityCheckID, Status = item.Status };

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -46,13 +46,27 @@ public class CheckEligibilityGateway : ICheckEligibility
             mappedBulkedChecks.Add(item);
         } 
 
-       _db.BulkInsert_EligibilityCheck(mappedBulkedChecks);
+        // Insert all rows into the DB BEFORE sending any queue messages,
+        // so the engine never processes a message for a row that doesn't exist yet.
+        _db.BulkInsert_EligibilityCheck(mappedBulkedChecks);
+
+        // Now send queue messages for records that weren't resolved from the hash cache.
+        foreach (var item in mappedBulkedChecks.Where(x => x.Status == CheckEligibilityStatus.queuedForProcessing))
+        {
+            await _storageQueueMessageGateway.SendMessage(item);
+        }
     }
     public async Task<PostCheckResult> PostCheck<T>(T data, CheckMetaData meta) where T : IEligibilityServiceType {
 
         var item = await MapCheck(data, meta);
         await _db.CheckEligibilities.AddAsync(item);
         await _db.SaveChangesAsync();
+
+        // Send queue message after the row is committed to the DB.
+        if (item.Status == CheckEligibilityStatus.queuedForProcessing)
+        {
+            await _storageQueueMessageGateway.SendMessage(item);
+        }
 
         return new PostCheckResult { Id = item.EligibilityCheckID, Status = item.Status };
 
@@ -118,7 +132,8 @@ public class CheckEligibilityGateway : ICheckEligibility
             }
             if (checkHashResult == null)
             {
-                var queue = await _storageQueueMessageGateway.SendMessage(item);
+                // Queue message will be sent by the caller (PostCheck bulk) after BulkInsert,
+                // or directly here for single checks.
             }
 
             return item;
@@ -201,6 +216,7 @@ public class CheckEligibilityGateway : ICheckEligibility
             var CheckData = GetCheckProcessData(result.Type, result.CheckData);
             if (isBatchRecord)
             {
+                item.EligibilityCheckID = result.EligibilityCheckID;
                 item.Status = result.Status.ToString();
                 item.Created = result.Created;
                 item.ClientIdentifier = CheckData.ClientIdentifier;

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -9,10 +9,8 @@ using CheckYourEligibility.API.Domain.Exceptions;
 using CheckYourEligibility.API.Gateways.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
-using System.Collections;
 using System.Security.Cryptography;
 using System.Text;
-using System.Security.Claims;
 
 namespace CheckYourEligibility.API.Gateways;
 
@@ -41,10 +39,25 @@ public class CheckEligibilityGateway : ICheckEligibility
     public async Task PostCheck<T>(T data, string groupId, CheckMetaData meta) where T : IEnumerable<IEligibilityServiceType>
     {
         _groupId = groupId;
-        foreach (var item in data) await PostCheck(item, meta);
-    }
+        List<EligibilityCheck> mappedBulkedChecks = new(); 
+        foreach (var d in data) {
+           
+           var item = await MapCheck(d, meta);
+            mappedBulkedChecks.Add(item);
+        } 
 
-    public async Task<PostCheckResult> PostCheck<T>(T data, CheckMetaData meta) where T : IEligibilityServiceType
+       _db.BulkInsert_EligibilityCheck(mappedBulkedChecks);
+    }
+    public async Task<PostCheckResult> PostCheck<T>(T data, CheckMetaData meta) where T : IEligibilityServiceType {
+
+        var item = await MapCheck(data, meta);
+        await _db.CheckEligibilities.AddAsync(item);
+        await _db.SaveChangesAsync();
+
+        return new PostCheckResult { Id = item.EligibilityCheckID, Status = item.Status };
+
+    }
+    public async Task<EligibilityCheck> MapCheck<T>(T data, CheckMetaData meta) where T : IEligibilityServiceType
     {
         var item = _mapper.Map<EligibilityCheck>(data);
 
@@ -102,16 +115,12 @@ public class CheckEligibilityGateway : ICheckEligibility
                     }
                 }
             }
-
-            await _db.CheckEligibilities.AddAsync(item);
-            await _db.SaveChangesAsync();
-            //TODO: The message queueing logic should sit in the use case, targeting the storage queue gateway
             if (checkHashResult == null)
             {
                 var queue = await _storageQueueMessageGateway.SendMessage(item);
             }
 
-            return new PostCheckResult { Id = item.EligibilityCheckID, Status = item.Status };
+            return item;
         }
         catch (Exception ex)
         {

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -75,6 +75,7 @@ public class CheckEligibilityGateway : ICheckEligibility
             item.Created = DateTime.UtcNow;
             item.Updated = DateTime.UtcNow;
             item.Status = CheckEligibilityStatus.queuedForProcessing;
+
             if (meta != null)
             {
                 item.OrganisationID = meta.OrganisationID;

--- a/CheckYourEligibility.API/Gateways/Interfaces/IStorageQueueMessage.cs
+++ b/CheckYourEligibility.API/Gateways/Interfaces/IStorageQueueMessage.cs
@@ -1,8 +1,10 @@
-﻿using CheckYourEligibility.API.Domain;
+﻿using Azure.Storage.Queues;
+using CheckYourEligibility.API.Domain;
 
 namespace CheckYourEligibility.API.Gateways.Interfaces;
 
 public interface IStorageQueueMessage
 {
-    Task<string> SendMessage(EligibilityCheck item);
+    Task<string> SendMessage(EligibilityCheck item, QueueClient queueClient);
+    QueueClient GetQueueClient(string queueName);
 }

--- a/CheckYourEligibility.API/Gateways/StorageQueueMessageGateway.cs
+++ b/CheckYourEligibility.API/Gateways/StorageQueueMessageGateway.cs
@@ -40,12 +40,9 @@ public class StorageQueueMessageGateway : IStorageQueueMessage
     #region Private
 
     [ExcludeFromCodeCoverage(Justification = "Queue is external dependency.")]
-    //TODO: Ideally this method and whole class would live in the StorageQueue gateway
-    public async Task<string> SendMessage(EligibilityCheck item)
+    public async Task<string> SendMessage(EligibilityCheck item, QueueClient queueClient)
     {
         var queueName = _configuration[$"Queue:{(item.BulkCheckID.IsNullOrEmpty()?"Single":"Bulk")}:{item.Type.ToString()}"];
-
-        QueueClient queueClient = GetQueueClient(queueName);
         
         await queueClient.SendMessageAsync(
             JsonConvert.SerializeObject(new QueueMessageCheck
@@ -56,10 +53,12 @@ public class StorageQueueMessageGateway : IStorageQueueMessage
                 SetStatusUrl = $"{CheckLinks.GetLink}{item.EligibilityCheckID}/status"
             }));
 
+        
+
         return queueClient.Name;
     }
 
-    private QueueClient GetQueueClient(string queueName)
+    public QueueClient GetQueueClient(string queueName)
     {
         if (!_queues.ContainsKey(queueName))
         {

--- a/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
+++ b/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
@@ -1,11 +1,13 @@
 ﻿// Ignore Spelling: Fsm
 
-using System.Diagnostics.CodeAnalysis;
+using Azure.Messaging.EventGrid.SystemEvents;
+using CheckYourEligibility.API.Boundary.Requests;
 using CheckYourEligibility.API.Domain;
 using CheckYourEligibility.API.Domain.Enums;
 using EFCore.BulkExtensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Internal;
+using System.Diagnostics.CodeAnalysis;
 using ApplicationStatus = CheckYourEligibility.API.Domain.ApplicationStatus;
 
 [ExcludeFromCodeCoverage(Justification = "framework")]
@@ -96,7 +98,20 @@ public class EligibilityCheckContext : DbContext, IEligibilityCheckContext
     {
         return base.SaveChanges();
     }
+    public void BulkInsert_EligibilityCheck(IEnumerable<EligibilityCheck> data) 
+    {
+        using var transaction = base.Database.BeginTransaction();
+        try
+        {           
+            this.BulkInsert(data);
+            transaction.Commit();
+        }
+        catch (Exception ex) {
 
+            transaction.Rollback();
+        }
+        
+    }
     public void BulkInsert_FreeSchoolMealsHMRC(IEnumerable<FreeSchoolMealsHMRC> data)
     {
         using var transaction = base.Database.BeginTransaction();
@@ -114,6 +129,7 @@ public class EligibilityCheckContext : DbContext, IEligibilityCheckContext
     {
         this.BulkInsert(data);
     }
+
     public void BulkInsertOrUpdate_LocalAuthority(IEnumerable<LocalAuthority> data)
     {
 
@@ -165,10 +181,6 @@ public class EligibilityCheckContext : DbContext, IEligibilityCheckContext
             transaction.Commit();
         }
     }
-
-
-
-    
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/CheckYourEligibility.API/Infrastructure/IEligibilityCheckContext.cs
+++ b/CheckYourEligibility.API/Infrastructure/IEligibilityCheckContext.cs
@@ -34,4 +34,6 @@ public interface IEligibilityCheckContext
     void BulkInsert_MultiAcademyTrusts(IEnumerable<MultiAcademyTrust> trustData, IEnumerable<MultiAcademyTrustEstablishment> schoolData);
     void BulkInsertOrUpdate_Establishment(IEnumerable<Establishment> data);
     void BulkInsertOrUpdate_LocalAuthority(IEnumerable<LocalAuthority> data);
+    void BulkInsert_EligibilityCheck(IEnumerable<EligibilityCheck> data);
+
 }

--- a/CheckYourEligibility.API/Usecases/CheckEligibilityBulkUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CheckEligibilityBulkUseCase.cs
@@ -4,6 +4,7 @@ using CheckYourEligibility.API.Domain.Constants;
 using CheckYourEligibility.API.Domain.Enums;
 using CheckYourEligibility.API.Gateways.Interfaces;
 using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
 using BulkCheck = CheckYourEligibility.API.Domain.BulkCheck;
 using ValidationException = CheckYourEligibility.API.Domain.Exceptions.ValidationException;
 
@@ -32,6 +33,7 @@ public class CheckEligibilityBulkUseCase : ICheckEligibilityBulkUseCase
     private readonly IBulkCheck _bulkCheckGateway;
     private readonly ICheckEligibility _checkEligibilityGateway;
     private readonly ILogger<CheckEligibilityBulkUseCase> _logger;
+    private readonly IServiceScopeFactory _scopeFactory;
 
     /// <summary>
     /// Use case for bulk eligibility checking operations
@@ -41,13 +43,15 @@ public class CheckEligibilityBulkUseCase : ICheckEligibilityBulkUseCase
         ICheckEligibility checkEligibilityGateway,
         IBulkCheck bulkCheckGateway,
         IAudit auditGateway,
-        ILogger<CheckEligibilityBulkUseCase> logger)
+        ILogger<CheckEligibilityBulkUseCase> logger,
+        IServiceScopeFactory scopeFactory)
     {
         _validator = validator;
         _checkEligibilityGateway = checkEligibilityGateway;
         _bulkCheckGateway = bulkCheckGateway;
         _auditGateway = auditGateway;
         _logger = logger;
+        _scopeFactory = scopeFactory;
     }
 
     public async Task<CheckEligibilityResponseBulk> Execute<T>(
@@ -120,11 +124,27 @@ public class CheckEligibilityBulkUseCase : ICheckEligibilityBulkUseCase
         };
 
         await _bulkCheckGateway.CreateBulkCheck(bulkCheck);
-
-        await _checkEligibilityGateway.PostCheck(bulkData, groupId, meta);
-
         await _auditGateway.CreateAuditEntry(AuditType.BulkCheck, groupId);
 
+        // Capture the data as a typed list before the request scope ends.
+        // PostCheck runs in its own DI scope so it owns its DbContext and
+        // other scoped services for as long as the background work takes.
+        // Each invocation gets a fresh gateway instance, so concurrent bulk
+        // submissions cannot share state or overwrite each other's groupId.
+        var capturedData = ((IEnumerable<IEligibilityServiceType>)bulkData).ToList();
+        _ = Task.Run(async () =>
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var gateway = scope.ServiceProvider.GetRequiredService<ICheckEligibility>();
+            try
+            {
+                await gateway.PostCheck(capturedData, groupId, meta);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Background PostCheck failed for bulk check group ID: {GroupId}", groupId);
+            }
+        });
 
         _logger.LogInformation($"Bulk eligibility check created with group ID: {groupId}");
         return new CheckEligibilityResponseBulk

--- a/CheckYourEligibility.API/Usecases/ProcessEligibilityBulkCheckUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ProcessEligibilityBulkCheckUseCase.cs
@@ -111,7 +111,7 @@ public class ProcessEligibilityBulkCheckUseCase : IProcessEligibilityBulkCheckUs
                     {
                         _logger.LogError(ex, "Queue processing");
                         // If we've had exceptions on this item more than retry limit
-                        if (item.DequeueCount >= _configuration.GetValue<int>("QueueRetries"))
+                        if (item.DequeueCount >= _configuration.GetValue<int>($"Queue:Settings:{queueName}:Retries"))
                         {
                             await _checkEligibilityGateway.UpdateEligibilityCheckStatus(checkData.Guid,
                                 new EligibilityCheckStatusData { Status = CheckEligibilityStatus.error }, dbContext);


### PR DESCRIPTION
Bulk processing now runs in a background task using IServiceScopeFactory, so the API responds straight away while the records are inserted and queued in the background.
Queue messages were being sent before rows were inserted into the DB. Changed to bulk DB insert first, then send queue messages.
Added public string? EligibilityCheckID { get; set; } in CheckEligibilityItem for stuck records to be requeued. Haven't include the script for this but will add in a different PR.
