### PR TITLE
Add tier property to response models and relevant db tables

### DIFF
--- a/CheckYourEligibility.API/Boundary/Responses/ApplicationResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/ApplicationResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace CheckYourEligibility.API.Boundary.Responses;
+﻿using CheckYourEligibility.API.Domain.Enums;
+
+namespace CheckYourEligibility.API.Boundary.Responses;
 
 public class ApplicationResponse
 {
@@ -15,6 +17,7 @@ public class ApplicationResponse
     public string ChildLastName { get; set; }
     public string ChildDateOfBirth { get; set; }
     public string Status { get; set; }
+    public EligibilityTier? Tier { get; set; } 
     public ApplicationUser User { get; set; }
     public DateTime Created { get; set; }
     public List<ApplicationEvidenceResponse>? Evidence { get; set; }

--- a/CheckYourEligibility.API/Boundary/Responses/ApplicationStatusRestoreResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/ApplicationStatusRestoreResponse.cs
@@ -1,3 +1,5 @@
+using CheckYourEligibility.API.Domain.Enums;
+
 namespace CheckYourEligibility.API.Boundary.Responses;
 
 public class ApplicationStatusRestoreResponse
@@ -8,5 +10,7 @@ public class ApplicationStatusRestoreResponse
 public class ApplicationStatusRestoreResponseData
 {
     public string Status { get; set; }
+    public EligibilityTier? Tier { get; set; }
+
     public DateTime Updated { get; set; }
 }

--- a/CheckYourEligibility.API/Boundary/Responses/ApplicationUpdateResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/ApplicationUpdateResponse.cs
@@ -1,5 +1,7 @@
 // Ignore Spelling: Fsm
 
+using CheckYourEligibility.API.Domain.Enums;
+
 namespace CheckYourEligibility.API.Boundary.Responses;
 
 public class ApplicationUpdateResponse
@@ -10,5 +12,6 @@ public class ApplicationUpdateResponse
 public class ApplicationUpdateDataResponse
 {
     public string Status { get; set; }
+    public EligibilityTier? Tier { get; set; }
     public int? EstablishmentUrn { get; set; }
 }

--- a/CheckYourEligibility.API/Boundary/Responses/CheckEligibilityItemResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/CheckEligibilityItemResponse.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using CheckYourEligibility.API.Domain.Enums;
+using Newtonsoft.Json;
 
 namespace CheckYourEligibility.API.Boundary.Responses;
 
@@ -7,7 +8,6 @@ public class CheckEligibilityItemBase
     public string NationalInsuranceNumber { get; set; }
 
     public string Status { get; set; }
-
     public DateTime Created { get; set; }
 }
 
@@ -26,6 +26,9 @@ public class CheckEligibilityItem : CheckEligibilityItemBase
     public string ValidityEndDate { get; set; }
     public string GracePeriodEndDate { get; set; }
     public string EligibilityCode { get; set; }
+    
+    public EligibilityTier? Tier { get; set; }
+
 }
 
 public class CheckEligibilityItemResponse

--- a/CheckYourEligibility.API/Boundary/Responses/CheckEligibilityStatusResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/CheckEligibilityStatusResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace CheckYourEligibility.API.Boundary.Responses;
+﻿using CheckYourEligibility.API.Domain.Enums;
+
+namespace CheckYourEligibility.API.Boundary.Responses;
 
 public class CheckEligibilityStatusResponse
 {
@@ -8,4 +10,6 @@ public class CheckEligibilityStatusResponse
 public class StatusValue
 {
     public string Status { get; set; }
+
+    public EligibilityTier? Tier { get; set; }
 }

--- a/CheckYourEligibility.API/Boundary/Responses/EligibilityCheckReportItem.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/EligibilityCheckReportItem.cs
@@ -9,6 +9,7 @@ public class EligibilityCheckReportItem
    public DateTime DateOfBirth { get; set; }
    public DateTime DateCheckSubmitted { get; set; }
    public CheckEligibilityStatus Outcome { get; set; }
+   public EligibilityTier? Tier { get; set; }
    public CheckType CheckType { get; set; } = CheckType.BulkChecks;
    public string CheckedBy { get; set; }  
 }

--- a/CheckYourEligibility.API/Boundary/Responses/PostCheckResult.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/PostCheckResult.cs
@@ -5,5 +5,7 @@ namespace CheckYourEligibility.API.Boundary.Responses;
 public class PostCheckResult
 {
     public string Id { get; set; }
+
+    public EligibilityTier? Tier { get; set; }
     public CheckEligibilityStatus Status { get; set; }
 }

--- a/CheckYourEligibility.API/Domain/EligibilityCheck.cs
+++ b/CheckYourEligibility.API/Domain/EligibilityCheck.cs
@@ -1,9 +1,8 @@
 ﻿// Ignore Spelling: Fsm
 
+using CheckYourEligibility.API.Domain.Enums;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
-using CheckYourEligibility.API.Domain.Enums;
-using Microsoft.EntityFrameworkCore;
 
 namespace CheckYourEligibility.API.Domain;
 
@@ -57,7 +56,7 @@ public class EligibilityCheck
     /// The bulk check entity if this is part of a bulk operation
     /// </summary>
     public virtual BulkCheck? BulkCheck { get; set; }
-    
+
     /// <summary>
     /// The serialized check data
     /// </summary>
@@ -78,7 +77,7 @@ public class EligibilityCheck
     /// else OrganisationID = 0
     /// </summary>
     [Column(TypeName = "int")]
-    public int? OrganisationID{ get; set; }
+    public int? OrganisationID { get; set; }
 
     /// <summary>
     /// What type of organisation is making the check
@@ -87,9 +86,15 @@ public class EligibilityCheck
     /// </summary>
     [Column(TypeName = "nvarchar(20)")]
     public string? OrganisationType { get; set; }
-    
+
     /// <summary>
     /// Soft delete flag - if true, the record is considered deleted and should be ignored in queries
     /// </summary>
-    public bool IsDeleted { get; set; } 
+    public bool IsDeleted { get; set; }
+
+    /// <summary>
+    /// Expanded FSM tiers support - targeted/expanded
+    /// </summary>
+    [Column(TypeName = "nvarchar(50)")]
+    public EligibilityTier? Tier {get; set;}
 }

--- a/CheckYourEligibility.API/Domain/EligibilityCheckHash.cs
+++ b/CheckYourEligibility.API/Domain/EligibilityCheckHash.cs
@@ -20,4 +20,10 @@ public class EligibilityCheckHash
     [Column(TypeName = "varchar(100)")] public CheckEligibilityStatus Outcome { get; set; }
 
     [Column(TypeName = "varchar(100)")] public ProcessEligibilityCheckSource Source { get; set; }
+
+    /// <summary>
+    /// Expanded FSM tiers support - targeted/expanded
+    /// </summary>
+    [Column(TypeName = "nvarchar(50)")]
+    public EligibilityTier? Tier { get; set; }
 }

--- a/CheckYourEligibility.API/Domain/Enums/EligibilityTier.cs
+++ b/CheckYourEligibility.API/Domain/Enums/EligibilityTier.cs
@@ -1,0 +1,18 @@
+﻿namespace CheckYourEligibility.API.Domain.Enums
+{
+    /// <summary>
+    /// To support new FSM policy
+    /// where everyone on UC is Eligible to receive FSM
+    /// </summary>
+    public enum EligibilityTier
+    {
+        /// <summary>
+        /// Check is below the threshold
+        /// </summary>
+        Targeted,
+        /// <summary>
+        /// Check is above the threshold
+        /// </summary>
+        Expanded
+    }
+}

--- a/CheckYourEligibility.API/Migrations/20260423101738_Add_TierToEligibilityCheckLikeTables.Designer.cs
+++ b/CheckYourEligibility.API/Migrations/20260423101738_Add_TierToEligibilityCheckLikeTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CheckYourEligibility.API.Migrations
 {
     [DbContext(typeof(EligibilityCheckContext))]
-    partial class EligibilityCheckContextModelSnapshot : ModelSnapshot
+    [Migration("20260423101738_Add_TierToEligibilityCheckLikeTables")]
+    partial class Add_TierToEligibilityCheckLikeTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -79,6 +82,10 @@ namespace CheckYourEligibility.API.Migrations
 
                     b.Property<string>("Status")
                         .HasColumnType("varchar(100)");
+
+                    b.Property<string>("Tier")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Type")
                         .IsRequired()

--- a/CheckYourEligibility.API/Migrations/20260423101738_Add_TierToEligibilityCheckLikeTables.cs
+++ b/CheckYourEligibility.API/Migrations/20260423101738_Add_TierToEligibilityCheckLikeTables.cs
@@ -1,0 +1,50 @@
+﻿using CheckYourEligibility.API.Domain.Enums;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CheckYourEligibility.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_TierToEligibilityCheckLikeTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Tier",
+                table: "EligibilityCheckHashes",
+                type: "nvarchar(50)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Tier",
+                table: "EligibilityCheck",
+                type: "nvarchar(50)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Tier",
+                table: "Applications",
+                type: "nvarchar(50)",
+                nullable: false,
+                defaultValue: EligibilityTier.Targeted);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Tier",
+                table: "EligibilityCheckHashes");
+
+            migrationBuilder.DropColumn(
+                name: "Tier",
+                table: "EligibilityCheck");
+
+            migrationBuilder.DropColumn(
+                name: "Tier",
+                table: "Applications");
+        }
+    }
+}

--- a/CheckYourEligibility.API/Migrations/20260423110423_Remove_TierFromApplications.Designer.cs
+++ b/CheckYourEligibility.API/Migrations/20260423110423_Remove_TierFromApplications.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CheckYourEligibility.API.Migrations
 {
     [DbContext(typeof(EligibilityCheckContext))]
-    partial class EligibilityCheckContextModelSnapshot : ModelSnapshot
+    [Migration("20260423110423_Remove_TierFromApplications")]
+    partial class Remove_TierFromApplications
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CheckYourEligibility.API/Migrations/20260423110423_Remove_TierFromApplications.cs
+++ b/CheckYourEligibility.API/Migrations/20260423110423_Remove_TierFromApplications.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CheckYourEligibility.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class Remove_TierFromApplications : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Tier",
+                table: "Applications");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Tier",
+                table: "Applications",
+                type: "nvarchar(50)",
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -67,7 +67,7 @@ Cypress.Commands.add('verifyPostEligibilityCheckResponse', (response) => {
   const totalElements = Object.keys(responseData).length + Object.keys(responseLinks).length;
 
   // Verfiy total number of elements
-  cy.verifyTotalElements(totalElements, 4);
+  cy.verifyTotalElements(totalElements, 5);
 
   // Verify response elements
   expect(response.body.data).to.have.property('status');

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -87,7 +87,7 @@ Cypress.Commands.add('verifyPostEligibilityBulkCheckResponse', (response) => {
   const totalElements = Object.keys(responseData).length + Object.keys(responseLinks).length;
 
   // Verfiy total number of elements
-  cy.verifyTotalElements(totalElements, 4);
+  cy.verifyTotalElements(totalElements, 5);
 
   // Verify response elements
   expect(response.body.data).to.have.property('status');
@@ -323,7 +323,7 @@ Cypress.Commands.add('verifyPostApplicationResponse', (response, requestData) =>
 
   // Verfiy total number of elements
   const totalElements = Object.keys(responseData).length + Object.keys(responseLinks).length;
-  cy.verifyTotalElements(totalElements, 18);
+  cy.verifyTotalElements(totalElements, 19);
 
   // Assertions to verify response data matches request data
   expect(responseData).to.have.property('id');
@@ -361,7 +361,7 @@ Cypress.Commands.add('verifyGetApplicationResponse', (response, expectedData) =>
     Object.keys(responseData.establishment).length +
     Object.keys(responseData.establishment.localAuthority).length +
     Object.keys(responseLinks).length;
-  cy.verifyTotalElements(totalElements, 23);
+  cy.verifyTotalElements(totalElements, 24);
 
   expect(responseData).to.have.property('id');
   expect(responseData).to.have.property('reference');


### PR DESCRIPTION
To support the new expanded FSM tiers we need to make the following changes to the API database and models:
- Add an enum for new eligibility tiers (targeted/expanded)
- Add Tier enum property to EligibilityCheck model and table
- Add Tier enum property to EligibilityCheckHashes model and table
- API endpoints which expose check statuses should include the new Tier property when data is present