### PR TITLE
ELIG-3018 Add eligibility tier display mapping to report items

### DIFF
--- a/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckReportItemsUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckReportItemsUseCaseTests.cs
@@ -70,11 +70,8 @@ namespace CheckYourEligibility.API.Tests.Usecases
             var reportId = Guid.NewGuid();
             string checkItem1Id = Guid.NewGuid().ToString();
             string checkItem2Id = Guid.NewGuid().ToString();
-            var reportItems = new List<EligibilityCheckReportItem>
-            {
-                new EligibilityCheckReportItem { EligibilityCheckID = checkItem1Id },
-                new EligibilityCheckReportItem { EligibilityCheckID = checkItem2Id }
-            };
+            string checkItem3Id = Guid.NewGuid().ToString();
+
             var checkData = new CheckProcessData { LastName = "Smith", NationalInsuranceNumber = "AB123456C", DateOfBirth = "2000-01-01" };
             var eligibilityCheck = new EligibilityCheck
             {
@@ -86,8 +83,9 @@ namespace CheckYourEligibility.API.Tests.Usecases
                 Type = CheckEligibilityType.FreeSchoolMeals,
                 UserName = "tester-1"
             };
+
             var checkData2 = new CheckProcessData { LastName = "Wilson", NationalInsuranceNumber = "AB123456A", DateOfBirth = "2000-01-01" };
-            var eligibilityCheckWithTier = new EligibilityCheck
+            var eligibilityCheckWithTargetedTier = new EligibilityCheck
             {
                 EligibilityCheckID = checkItem2Id,
                 CheckData = JsonConvert.SerializeObject(checkData2),
@@ -97,40 +95,67 @@ namespace CheckYourEligibility.API.Tests.Usecases
                 Type = CheckEligibilityType.FreeSchoolMeals,
                 UserName = "tester-2"
             };
+
+            var checkData3 = new CheckProcessData { LastName = "Brown", NationalInsuranceNumber = "AB123456B", DateOfBirth = "2000-01-01" };
+            var eligibilityCheckWithExpandedTier = new EligibilityCheck
+            {
+                EligibilityCheckID = checkItem3Id,
+                CheckData = JsonConvert.SerializeObject(checkData3),
+                Created = new DateTime(2024, 1, 1),
+                Status = CheckEligibilityStatus.eligible,
+                Tier = EligibilityTier.expanded,
+                Type = CheckEligibilityType.FreeSchoolMeals,
+                UserName = "tester-3"
+            };
+
             _mockReportingGateway.Setup(x => x.GetEligibilityReportById(reportId)).ReturnsAsync(new EligibilityCheckReport());
-            _mockReportingGateway.Setup(x => x.GetEligibilityChecksByReportId(reportId)).ReturnsAsync(new Dictionary<Guid, EligibilityCheck> {
+            _mockReportingGateway.Setup(x => x.GetEligibilityChecksByReportId(reportId)).ReturnsAsync(new Dictionary<Guid, EligibilityCheck>
+            {
                 { Guid.Parse(checkItem1Id), eligibilityCheck },
-                { Guid.Parse(checkItem2Id), eligibilityCheckWithTier } });
+                { Guid.Parse(checkItem2Id), eligibilityCheckWithTargetedTier },
+                { Guid.Parse(checkItem3Id), eligibilityCheckWithExpandedTier }
+            });
+
             // Act
             var result = await _sut.Execute(reportId.ToString());
-            // Assert
 
-            ;
+            // Assert
             result.Data.Should().BeEquivalentTo(new[]
             {
-                new
-                {
-                    ParentName = "Smith",
-                    NationalInsuranceNumber = "AB123456C",
-                    DateOfBirth = "2000-01-01",
-                    CheckSubmittedDate = "2024-01-01",
-                    Outcome = "eligible",
-                    Tier = (string)null,
-                    CheckType = "FreeSchoolMeals",
-                    CheckedBy = "tester-1"
-                },
-                new
-                {
-                    ParentName = "Wilson",
-                    NationalInsuranceNumber = "AB123456A",
-                    DateOfBirth = "2000-01-01",
-                    CheckSubmittedDate = "2024-01-01",
-                    Outcome = "eligible",
-                    Tier = "targeted",
-                    CheckType = "FreeSchoolMeals",
-                    CheckedBy = "tester-2"
-                }
-            }, options => options.WithoutStrictOrdering());
+            new
+            {
+                ParentName = "Smith",
+                NationalInsuranceNumber = "AB123456C",
+                DateOfBirth = "2000-01-01",
+                CheckSubmittedDate = "2024-01-01",
+                Outcome = "eligible",
+                Tier = "N/A",
+                CheckType = "FreeSchoolMeals",
+                CheckedBy = "tester-1"
+            },
+            new
+            {
+                ParentName = "Wilson",
+                NationalInsuranceNumber = "AB123456A",
+                DateOfBirth = "2000-01-01",
+                CheckSubmittedDate = "2024-01-01",
+                Outcome = "eligible",
+                Tier = "Eligible targeted",
+                CheckType = "FreeSchoolMeals",
+                CheckedBy = "tester-2"
+            },
+            new
+            {
+                ParentName = "Brown",
+                NationalInsuranceNumber = "AB123456B",
+                DateOfBirth = "2000-01-01",
+                CheckSubmittedDate = "2024-01-01",
+                Outcome = "eligible",
+                Tier = "Eligible expanded",
+                CheckType = "FreeSchoolMeals",
+                CheckedBy = "tester-3"
+            }
+        }, options => options.WithoutStrictOrdering());
         }
     }
 }

--- a/CheckYourEligibility.API/Usecases/GetEligibilityCheckReportItemsUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetEligibilityCheckReportItemsUseCase.cs
@@ -1,4 +1,5 @@
 ﻿using CheckYourEligibility.API.Boundary.Responses;
+using CheckYourEligibility.API.Domain.Enums;
 using CheckYourEligibility.API.Domain.Exceptions;
 using CheckYourEligibility.API.Gateways;
 using Newtonsoft.Json;
@@ -59,7 +60,7 @@ namespace CheckYourEligibility.API.Usecases
                         DateOfBirth = checkData.DateOfBirth,
                         CheckSubmittedDate = check.Created.ToString("yyyy-MM-dd"),
                         Outcome = check.Status.ToString(),
-                        Tier = check.Tier?.ToString(),
+                        Tier = GetTierDisplayValue(check.Tier),
                         CheckType = check.Type.ToString(),
                         ProcessingType = check.BulkCheckID != null ? "Batch" : "Individual",
                         CheckedBy = check.UserName ?? ""
@@ -71,6 +72,16 @@ namespace CheckYourEligibility.API.Usecases
             return new EligibilityCheckReportItemsResponse
             {
                 Data = itemsList
+            };
+        }
+
+        private static string GetTierDisplayValue(EligibilityTier? tier)
+        {
+            return tier switch
+            {
+                EligibilityTier.targeted => "Eligible targeted",
+                EligibilityTier.expanded => "Eligible expanded",
+                _ => "N/A"
             };
         }
     }


### PR DESCRIPTION
Added eligibility tier display mapping to report item exports.

Report items now return:
- Eligible targeted
- Eligible expanded
- N/A

instead of exposing raw enum values or nulls.

Added unit test coverage for:
- null tier
- targeted tier
- expanded tier