### PR TITLE
Elig 3193 batch checks history page is slow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,6 +398,7 @@ FodyWeavers.xsd
 *.sln.iml
 /CheckYourEligibility.API/appsettings.Development.json
 /CheckYourEligibility.API/appsettings.Development.json
+/CheckYourEligibility.API/appsettings.local.json
 /.gitignore
 tests/cypress/cypress.env.json
 tests/cypress.env.json

--- a/CheckYourEligibility.API.Tests/Gateways/BulkCheckGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/BulkCheckGatewayTests.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Newtonsoft.Json;
+using DomainBulkCheck = CheckYourEligibility.API.Domain.BulkCheck;
 
 namespace CheckYourEligibility.API.Tests;
 
@@ -84,6 +85,211 @@ public class BulkCheckGatewayTests : TestBase.TestBase
         var context = (EligibilityCheckContext)_fakeInMemoryDb;
         await context.Database.EnsureDeletedAsync();
     }
+
+    #region GetBulkStatuses
+
+    [Test]
+    public async Task Given_InvalidLocalAuthorityId_GetBulkStatuses_Should_Return_EmptyList()
+    {
+        // Arrange – non-numeric LA ID
+        var result = await _sut.GetBulkStatuses("not-a-number", new List<int> { 201 });
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Given_UnauthorisedUser_GetBulkStatuses_Should_Return_EmptyList()
+    {
+        // Arrange – user only has access to LA 22, requests LA 201
+        var result = await _sut.GetBulkStatuses("201", new List<int> { 22 });
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Given_NoChecksExist_GetBulkStatuses_Should_Return_EmptyList()
+    {
+        // Arrange – no BulkChecks in DB for this LA
+        var result = await _sut.GetBulkStatuses("201", new List<int> { 201 });
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Given_BatchWithAllChecksComplete_GetBulkStatuses_Should_Return_CompletedStatus()
+    {
+        // Arrange
+        var bulkCheckId = Guid.NewGuid().ToString();
+        _fakeInMemoryDb.BulkChecks.Add(new DomainBulkCheck
+        {
+            BulkCheckID = bulkCheckId,
+            LocalAuthorityID = 201,
+            SubmittedDate = DateTime.UtcNow.AddDays(-1),
+            Filename = "test.csv",
+            FinalNameInCheck = "test.csv",
+            SubmittedBy = "test@test.com",
+            EligibilityType = CheckEligibilityType.FreeSchoolMeals,
+            NumberOfRecords = 2
+        });
+        _fakeInMemoryDb.CheckEligibilities.AddRange(
+            new EligibilityCheck { EligibilityCheckID = Guid.NewGuid().ToString(), BulkCheckID = bulkCheckId, Status = CheckEligibilityStatus.eligible,    IsDeleted = false, Type = CheckEligibilityType.FreeSchoolMeals, CheckData = "{}", Created = DateTime.UtcNow, Updated = DateTime.UtcNow },
+            new EligibilityCheck { EligibilityCheckID = Guid.NewGuid().ToString(), BulkCheckID = bulkCheckId, Status = CheckEligibilityStatus.notEligible, IsDeleted = false, Type = CheckEligibilityType.FreeSchoolMeals, CheckData = "{}", Created = DateTime.UtcNow, Updated = DateTime.UtcNow }
+        );
+        await _fakeInMemoryDb.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetBulkStatuses("201", new List<int> { 201 });
+
+        // Assert
+        result.Should().ContainSingle();
+        result!.First().Status.Should().Be(BulkCheckStatus.Completed);
+    }
+
+    [Test]
+    public async Task Given_BatchWithQueuedChecks_GetBulkStatuses_Should_Return_InProgressStatus()
+    {
+        // Arrange
+        var bulkCheckId = Guid.NewGuid().ToString();
+        _fakeInMemoryDb.BulkChecks.Add(new DomainBulkCheck
+        {
+            BulkCheckID = bulkCheckId,
+            LocalAuthorityID = 201,
+            SubmittedDate = DateTime.UtcNow.AddDays(-1),
+            Filename = "test.csv",
+            FinalNameInCheck = "test.csv",
+            SubmittedBy = "test@test.com",
+            EligibilityType = CheckEligibilityType.FreeSchoolMeals,
+            NumberOfRecords = 2
+        });
+        _fakeInMemoryDb.CheckEligibilities.AddRange(
+            new EligibilityCheck { EligibilityCheckID = Guid.NewGuid().ToString(), BulkCheckID = bulkCheckId, Status = CheckEligibilityStatus.eligible,              IsDeleted = false, Type = CheckEligibilityType.FreeSchoolMeals, CheckData = "{}", Created = DateTime.UtcNow, Updated = DateTime.UtcNow },
+            new EligibilityCheck { EligibilityCheckID = Guid.NewGuid().ToString(), BulkCheckID = bulkCheckId, Status = CheckEligibilityStatus.queuedForProcessing, IsDeleted = false, Type = CheckEligibilityType.FreeSchoolMeals, CheckData = "{}", Created = DateTime.UtcNow, Updated = DateTime.UtcNow }
+        );
+        await _fakeInMemoryDb.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetBulkStatuses("201", new List<int> { 201 });
+
+        // Assert
+        result.Should().ContainSingle();
+        result!.First().Status.Should().Be(BulkCheckStatus.InProgress);
+    }
+
+    [Test]
+    public async Task Given_NewlySubmittedBatch_WithNoChecksInsertedYet_GetBulkStatuses_Should_Return_InProgressStatus()
+    {
+        // Arrange – BulkCheck exists but EligibilityCheck rows not yet inserted
+        var bulkCheckId = Guid.NewGuid().ToString();
+        _fakeInMemoryDb.BulkChecks.Add(new DomainBulkCheck
+        {
+            BulkCheckID = bulkCheckId,
+            LocalAuthorityID = 201,
+            SubmittedDate = DateTime.UtcNow.AddMinutes(-1),
+            Filename = "test.csv",
+            FinalNameInCheck = "test.csv",
+            SubmittedBy = "test@test.com",
+            EligibilityType = CheckEligibilityType.FreeSchoolMeals,
+            NumberOfRecords = 100
+        });
+        await _fakeInMemoryDb.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetBulkStatuses("201", new List<int> { 201 });
+
+        // Assert
+        result.Should().ContainSingle();
+        result!.First().Status.Should().Be(BulkCheckStatus.InProgress);
+    }
+
+    [Test]
+    public async Task Given_BatchWhereAllChecksAreSoftDeleted_GetBulkStatuses_Should_Return_DeletedStatus()
+    {
+        // Arrange
+        var bulkCheckId = Guid.NewGuid().ToString();
+        _fakeInMemoryDb.BulkChecks.Add(new DomainBulkCheck
+        {
+            BulkCheckID = bulkCheckId,
+            LocalAuthorityID = 201,
+            SubmittedDate = DateTime.UtcNow.AddDays(-1),
+            Filename = "test.csv",
+            FinalNameInCheck = "test.csv",
+            SubmittedBy = "test@test.com",
+            EligibilityType = CheckEligibilityType.FreeSchoolMeals,
+            NumberOfRecords = 2
+        });
+        _fakeInMemoryDb.CheckEligibilities.AddRange(
+            new EligibilityCheck { EligibilityCheckID = Guid.NewGuid().ToString(), BulkCheckID = bulkCheckId, Status = CheckEligibilityStatus.eligible, IsDeleted = true, Type = CheckEligibilityType.FreeSchoolMeals, CheckData = "{}", Created = DateTime.UtcNow, Updated = DateTime.UtcNow },
+            new EligibilityCheck { EligibilityCheckID = Guid.NewGuid().ToString(), BulkCheckID = bulkCheckId, Status = CheckEligibilityStatus.eligible, IsDeleted = true, Type = CheckEligibilityType.FreeSchoolMeals, CheckData = "{}", Created = DateTime.UtcNow, Updated = DateTime.UtcNow }
+        );
+        await _fakeInMemoryDb.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetBulkStatuses("201", new List<int> { 201 });
+
+        // Assert
+        result.Should().ContainSingle();
+        result!.First().Status.Should().Be(BulkCheckStatus.Deleted);
+    }
+
+    [Test]
+    public async Task Given_BatchOlderThan7Days_GetBulkStatuses_Should_Not_Return_It()
+    {
+        // Arrange
+        var bulkCheckId = Guid.NewGuid().ToString();
+        _fakeInMemoryDb.BulkChecks.Add(new DomainBulkCheck
+        {
+            BulkCheckID = bulkCheckId,
+            LocalAuthorityID = 201,
+            SubmittedDate = DateTime.UtcNow.AddDays(-8),
+            Filename = "old.csv",
+            FinalNameInCheck = "old.csv",
+            SubmittedBy = "test@test.com",
+            EligibilityType = CheckEligibilityType.FreeSchoolMeals,
+            NumberOfRecords = 1
+        });
+        await _fakeInMemoryDb.SaveChangesAsync();
+
+        // Act – default includeLast7DaysOnly = true
+        var result = await _sut.GetBulkStatuses("201", new List<int> { 201 });
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Given_AdminUser_GetBulkStatuses_Should_Return_ChecksForRequestedLA()
+    {
+        // Arrange – admin user (allowedLocalAuthorityIds contains 0)
+        var bulkCheckId = Guid.NewGuid().ToString();
+        _fakeInMemoryDb.BulkChecks.Add(new DomainBulkCheck
+        {
+            BulkCheckID = bulkCheckId,
+            LocalAuthorityID = 999,
+            SubmittedDate = DateTime.UtcNow.AddDays(-1),
+            Filename = "test.csv",
+            FinalNameInCheck = "test.csv",
+            SubmittedBy = "admin@test.com",
+            EligibilityType = CheckEligibilityType.FreeSchoolMeals,
+            NumberOfRecords = 1
+        });
+        await _fakeInMemoryDb.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetBulkStatuses("999", new List<int> { 0 });
+
+        // Assert
+        result.Should().ContainSingle();
+        result!.First().BulkCheckID.Should().Be(bulkCheckId);
+    }
+
+    #endregion
 
     [Test]
     public void Given_InValidRequest_GetBulkStatus_Should_Return_null()

--- a/CheckYourEligibility.API/Gateways/BulkCheckGateway.cs
+++ b/CheckYourEligibility.API/Gateways/BulkCheckGateway.cs
@@ -174,47 +174,45 @@ public class BulkCheckGateway : IBulkCheck
             }
         }
 
-        // Execute query with optimized includes and projections
+        // Load only BulkCheck metadata - do NOT include EligibilityChecks navigation property,
+        // as that would load potentially 100,000+ rows into memory for large LAs.
         var bulkChecks = await query
-            .Include(x => x.EligibilityChecks)
-            .OrderByDescending(x => x.SubmittedDate) // Add ordering for consistent results and better UX
+            .OrderByDescending(x => x.SubmittedDate)
             .ToListAsync();
 
-        // Optimize status calculation using LINQ for better performance
+        if (bulkChecks.Count == 0)
+            return bulkChecks;
+
+        // Single aggregate query at the database level: count total and queued checks per BulkCheck.
+        // This replaces the previous approach of loading all individual EligibilityCheck rows.
+        // We count ALL rows (including soft-deleted) so we can distinguish:
+        //   - no rows at all   → just submitted, treat as InProgress
+        //   - rows but all deleted → Deleted
+        var bulkCheckIds = bulkChecks.Select(bc => bc.BulkCheckID).ToList();
+        var statusCounts = await _db.CheckEligibilities
+            .Where(x => bulkCheckIds.Contains(x.BulkCheckID!))
+            .GroupBy(x => x.BulkCheckID)
+            .Select(g => new
+            {
+                BulkCheckID = g.Key,
+                Total  = g.Count(x => !x.IsDeleted),
+                Queued = g.Count(x => !x.IsDeleted && x.Status == CheckEligibilityStatus.queuedForProcessing),
+                AnyRows = g.Count()
+            })
+            .ToDictionaryAsync(x => x.BulkCheckID!);
+
         foreach (var bulkCheck in bulkChecks)
         {
-            if (bulkCheck.EligibilityChecks?.Any() == true)
-            {
-                // Filter out deleted eligibility checks for status calculation
-                var eligibilityStatuses = bulkCheck.EligibilityChecks
-                    .Where(x => x.IsDeleted == false)
-                    .Select(x => x.Status).ToList();
-
-                // Use more efficient status checking
-                var queuedCount = eligibilityStatuses.Count(s => s == CheckEligibilityStatus.queuedForProcessing);
-                var errorCount = eligibilityStatuses.Count(s => s == CheckEligibilityStatus.error);
-                var totalCount = eligibilityStatuses.Count;
-
-                // Calculate expected status more efficiently
-                BulkCheckStatus expectedStatus;
-                if (totalCount == 0)
-                {
-                    // All records deleted - maintain current status or set to Deleted
-                    bulkCheck.Status = BulkCheckStatus.Deleted;
-                }
-                else if (queuedCount > 0)
-                {
-                    bulkCheck.Status = BulkCheckStatus.InProgress; // Queued
-                }
-                else if (queuedCount == 0)
-                {
-                    bulkCheck.Status = BulkCheckStatus.Completed; // All completed
-                }
-                else
-                {
-                    bulkCheck.Status = BulkCheckStatus.InProgress; // Partially completed
-                }
-            }
+            if (!statusCounts.TryGetValue(bulkCheck.BulkCheckID, out var counts))
+                // No EligibilityCheck rows at all — batch was just submitted; treat as in progress.
+                bulkCheck.Status = BulkCheckStatus.InProgress;
+            else if (counts.Total == 0)
+                // Rows exist but all are soft-deleted.
+                bulkCheck.Status = BulkCheckStatus.Deleted;
+            else if (counts.Queued > 0)
+                bulkCheck.Status = BulkCheckStatus.InProgress;
+            else
+                bulkCheck.Status = BulkCheckStatus.Completed;
         }
 
         return bulkChecks;

--- a/scripts/Seed-PerfTestData.sql
+++ b/scripts/Seed-PerfTestData.sql
@@ -2,13 +2,13 @@
 -- Seed-PerfTestData.sql
 -- LOCAL DEVELOPMENT ONLY — do NOT run against dev/staging/production.
 --
--- Creates 20 BulkChecks with 5,000 EligibilityChecks each (100,000 total)
+-- Creates 20 BulkChecks with 20,000 EligibilityChecks each (400,000 total)
 -- for LocalAuthorityID = 201, all submitted within the last 7 days.
 -- All rows tagged BulkCheckID LIKE 'perf-test-%' for easy cleanup.
 --
 -- PURPOSE: Reproduce the GetBulkStatuses timeout bug locally.
--- Each batch is capped at 5,000 rows (the real application limit).
--- 20 batches × 5,000 = 100,000 rows, spaced 8 hours apart so all
+-- Each batch uses 20,000 rows (exceeds the 5,000 app limit intentionally for stress testing).
+-- 20 batches × 20,000 = 400,000 rows, spaced 8 hours apart so all
 -- 20 batches fall within the 7-day query window (20 × 8h = 160h < 168h).
 --
 -- CLEANUP: Run the DELETE block at the bottom when done.
@@ -17,8 +17,8 @@
 SET NOCOUNT ON;
 
 DECLARE @LAID        INT = 201;
-DECLARE @BatchCount  INT = 21;      -- set to 20 for full perf test
-DECLARE @PerBatch    INT = 5000;      -- set to 5000 for full perf test
+DECLARE @BatchCount  INT = 21;
+DECLARE @PerBatch    INT = 20000;  -- intentionally above the 5k app limit for stress testing
 
 -- ---------------------------------------------------------------------------
 -- Cleanup any previous run

--- a/scripts/Seed-PerfTestData.sql
+++ b/scripts/Seed-PerfTestData.sql
@@ -1,0 +1,122 @@
+-- =============================================================================
+-- Seed-PerfTestData.sql
+-- LOCAL DEVELOPMENT ONLY — do NOT run against dev/staging/production.
+--
+-- Creates 20 BulkChecks with 5,000 EligibilityChecks each (100,000 total)
+-- for LocalAuthorityID = 201, all submitted within the last 7 days.
+-- All rows tagged BulkCheckID LIKE 'perf-test-%' for easy cleanup.
+--
+-- PURPOSE: Reproduce the GetBulkStatuses timeout bug locally.
+-- Each batch is capped at 5,000 rows (the real application limit).
+-- 20 batches × 5,000 = 100,000 rows, spaced 8 hours apart so all
+-- 20 batches fall within the 7-day query window (20 × 8h = 160h < 168h).
+--
+-- CLEANUP: Run the DELETE block at the bottom when done.
+-- =============================================================================
+
+SET NOCOUNT ON;
+
+DECLARE @LAID        INT = 201;
+DECLARE @BatchCount  INT = 21;      -- set to 20 for full perf test
+DECLARE @PerBatch    INT = 5000;      -- set to 5000 for full perf test
+
+-- ---------------------------------------------------------------------------
+-- Cleanup any previous run
+-- ---------------------------------------------------------------------------
+PRINT 'Cleaning up previous perf-test data...';
+DELETE FROM [dbo].[EligibilityCheck] WHERE BulkCheckID LIKE 'perf-test-%';
+DELETE FROM [dbo].[BulkChecks]       WHERE BulkCheckID LIKE 'perf-test-%';
+
+-- ---------------------------------------------------------------------------
+-- Insert BulkChecks spread across the last 6 days
+-- ---------------------------------------------------------------------------
+PRINT 'Inserting BulkChecks...';
+
+DECLARE @i INT = 1;
+WHILE @i <= @BatchCount
+BEGIN
+    INSERT INTO [dbo].[BulkChecks]
+        (BulkCheckID, Filename, EligibilityType, SubmittedDate, SubmittedBy,
+         LocalAuthorityID, FinalNameInCheck, NumberOfRecords)
+    VALUES (
+        'perf-test-' + CAST(@i AS VARCHAR(10)),
+        'perf-test-batch-' + CAST(@i AS VARCHAR(10)) + '.csv',
+        'FreeSchoolMeals',
+        DATEADD(HOUR, -(@i * 8), GETUTCDATE()),  -- 8h spacing keeps 20 batches within 7 days
+        'perf-test@dfe.gov.uk',
+        @LAID,
+        'perf-test-batch-' + CAST(@i AS VARCHAR(10)) + '.csv',
+        @PerBatch
+    );
+    SET @i = @i + 1;
+END
+
+PRINT 'BulkChecks inserted: ' + CAST(@BatchCount AS VARCHAR);
+
+-- ---------------------------------------------------------------------------
+-- Insert EligibilityCheck rows via tally-table (no per-row CURSOR)
+-- ---------------------------------------------------------------------------
+PRINT 'Inserting EligibilityCheck rows (this may take a few seconds)...';
+
+DECLARE @b INT = 1;
+DECLARE @bcid VARCHAR(50);
+
+WHILE @b <= @BatchCount
+BEGIN
+    SET @bcid = 'perf-test-' + CAST(@b AS VARCHAR(10));
+
+    ;WITH
+        N1  AS (SELECT 1 n UNION ALL SELECT 1),
+        N2  AS (SELECT 1 n FROM N1  a, N1  b),
+        N4  AS (SELECT 1 n FROM N2  a, N2  b),
+        N8  AS (SELECT 1 n FROM N4  a, N4  b),
+        N16 AS (SELECT 1 n FROM N8  a, N8  b),   -- 65,536 rows — enough for 25,000
+        Tally AS (SELECT ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS rn FROM N16)
+    INSERT INTO [dbo].[EligibilityCheck]
+        (EligibilityCheckID, [Type], [Status], Created, Updated,
+         CheckData, Source, UserName, OrganisationID, OrganisationType,
+         IsDeleted, BulkCheckID)
+    SELECT TOP (@PerBatch)
+        'perf-' + @bcid + '-' + CAST(rn AS VARCHAR(10)),
+        'FreeSchoolMeals',
+        CASE (rn % 3)
+            WHEN 0 THEN 'eligible'
+            WHEN 1 THEN 'notEligible'
+            ELSE        'parentNotFound'
+        END,
+        DATEADD(HOUR, -(@b * 8), GETUTCDATE()),
+        DATEADD(HOUR, -(@b * 8), GETUTCDATE()),
+        '{"LastName":"TESTER","DateOfBirth":"1990-01-01","NationalInsuranceNumber":"NN000001C"}',
+        'bulk',
+        'perf-test@dfe.gov.uk',
+        @LAID,
+        'local-authority',
+        0,
+        @bcid
+    FROM Tally;
+
+    PRINT '  Batch ' + CAST(@b AS VARCHAR) + ' done (' + @bcid + ')';
+    SET @b = @b + 1;
+END
+
+-- ---------------------------------------------------------------------------
+-- Summary
+-- ---------------------------------------------------------------------------
+PRINT '';
+PRINT '=== Seed complete ===';
+
+SELECT
+    b.BulkCheckID,
+    b.SubmittedDate,
+    COUNT(e.EligibilityCheckID) AS CheckCount
+FROM [dbo].[BulkChecks] b
+LEFT JOIN [dbo].[EligibilityCheck] e ON e.BulkCheckID = b.BulkCheckID
+WHERE b.BulkCheckID LIKE 'perf-test-%'
+GROUP BY b.BulkCheckID, b.SubmittedDate
+ORDER BY b.SubmittedDate DESC;
+
+-- ---------------------------------------------------------------------------
+-- CLEANUP — run this block to remove all perf-test rows
+-- ---------------------------------------------------------------------------
+-- DELETE FROM [dbo].[EligibilityCheck] WHERE BulkCheckID LIKE 'perf-test-%';
+-- DELETE FROM [dbo].[BulkChecks]       WHERE BulkCheckID LIKE 'perf-test-%';

--- a/scripts/Test-BulkCheckPerformance.ps1
+++ b/scripts/Test-BulkCheckPerformance.ps1
@@ -1,0 +1,122 @@
+# Test-BulkCheckPerformance.ps1
+#
+# Calls GET /bulk-check/search?organisationId={id} and reports response time.
+# Run against local or dev to verify the GetBulkStatuses performance fix.
+#
+# USAGE — local:
+#   .\Test-BulkCheckPerformance.ps1
+#
+# USAGE — dev (supply credentials and a known large LA):
+#   .\Test-BulkCheckPerformance.ps1 `
+#       -ApiBase      "https://dev.eligibility-checking-engine.education.gov.uk" `
+#       -ClientId     "<your-dev-client-id>" `
+#       -ClientSecret "<your-dev-client-secret>" `
+#       -OrganisationId "<la-id-with-large-volume>"
+
+param(
+    # API base URL
+    # Local: https://localhost:7117
+    # Dev:   https://dev.eligibility-checking-engine.education.gov.uk
+    [string]$ApiBase        = "https://localhost:7117",
+
+    # OAuth2 client credentials — must have bulk_check + local_authority scope
+    [string]$ClientId       = "anoop",
+    [string]$ClientSecret   = "Surf1ng_1",
+
+    # Local authority ID to query.
+    # On dev, use a known large LA (e.g. one referenced in the bug ticket).
+    [string]$OrganisationId = "201",
+
+    [int]$Runs = 3     # number of timed calls to average
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-TimeColour([long]$ms) {
+    if ($ms -lt 1000) { 'Green' } elseif ($ms -lt 5000) { 'Yellow' } else { 'Red' }
+}
+
+# ---------------------------------------------------------------------------
+# Step 1 — Authenticate
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "Authenticating as '$ClientId' against $ApiBase..." -ForegroundColor Yellow
+
+$tokenBody = @{
+    client_id     = $ClientId
+    client_secret = $ClientSecret
+    grant_type    = "client_credentials"
+    scope         = "bulk_check local_authority check"
+}
+
+$tokenResponse = Invoke-RestMethod `
+    -Uri "$ApiBase/oauth2/token" `
+    -Method Post `
+    -Body $tokenBody `
+    -ContentType "application/x-www-form-urlencoded" `
+    -SkipCertificateCheck
+
+$token = $tokenResponse.access_token
+if (-not $token) { throw "Failed to obtain access token." }
+Write-Host "  Token obtained." -ForegroundColor Green
+
+$headers = @{ Authorization = "Bearer $token" }
+$url     = "$ApiBase/bulk-check/search?organisationId=$OrganisationId"
+
+Write-Host ""
+Write-Host "Target:  GET $url" -ForegroundColor Cyan
+Write-Host "Runs:    $Runs"
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# Step 2 — Warm-up (not timed — avoids JIT / connection setup skew)
+# ---------------------------------------------------------------------------
+Write-Host "Warm-up call..." -ForegroundColor DarkGray
+try {
+    $null = Invoke-RestMethod -Uri $url -Method Get -Headers $headers -SkipCertificateCheck
+    Write-Host "  Warm-up OK." -ForegroundColor DarkGray
+} catch {
+    Write-Host "  Warm-up failed: $($_.Exception.Message)" -ForegroundColor Red
+}
+
+# ---------------------------------------------------------------------------
+# Step 3 — Timed runs
+# ---------------------------------------------------------------------------
+$times = @()
+
+for ($run = 1; $run -le $Runs; $run++) {
+    Write-Host "Run $run/$Runs..." -ForegroundColor Yellow -NoNewline
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+    try {
+        $response = Invoke-RestMethod `
+            -Uri $url -Method Get -Headers $headers -SkipCertificateCheck
+
+        $sw.Stop()
+        $ms    = $sw.ElapsedMilliseconds
+        $times += $ms
+        $count = ($response.checks | Measure-Object).Count
+
+        Write-Host (" {0,6:N0} ms   ({1} BulkChecks returned)" -f $ms, $count) -ForegroundColor (Get-TimeColour $ms)
+    } catch {
+        $sw.Stop()
+        Write-Host (" FAILED after {0:N0} ms — {1}" -f $sw.ElapsedMilliseconds, $_.Exception.Message) -ForegroundColor Red
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Step 4 — Summary
+# ---------------------------------------------------------------------------
+if ($times.Count -gt 0) {
+    $avg = ($times | Measure-Object -Average).Average
+    $min = ($times | Measure-Object -Minimum).Minimum
+    $max = ($times | Measure-Object -Maximum).Maximum
+
+    Write-Host ""
+    Write-Host "=== Results ===" -ForegroundColor Cyan
+    Write-Host ("  Min:  {0,6:N0} ms" -f $min) -ForegroundColor (Get-TimeColour $min)
+    Write-Host ("  Max:  {0,6:N0} ms" -f $max)
+    Write-Host ("  Avg:  {0,6:N0} ms" -f $avg) -ForegroundColor (Get-TimeColour $avg)
+    Write-Host ""
+}

--- a/scripts/Test-BulkCheckPerformance.ps1
+++ b/scripts/Test-BulkCheckPerformance.ps1
@@ -20,12 +20,12 @@ param(
     [string]$ApiBase        = "https://localhost:7117",
 
     # OAuth2 client credentials — must have bulk_check + local_authority scope
-    [string]$ClientId       = "anoop",
-    [string]$ClientSecret   = "Surf1ng_1",
+    [string]$ClientId       = "<your-client-id>",
+    [string]$ClientSecret   = "<your-client-secret>",
 
     # Local authority ID to query.
     # On dev, use a known large LA (e.g. one referenced in the bug ticket).
-    [string]$OrganisationId = "201",
+    [string]$OrganisationId = "<your-organisation-id>",
 
     [int]$Runs = 3     # number of timed calls to average
 )


### PR DESCRIPTION
Deployed the code to dev for testing and redeployed main branch code.

Setup: In dev created 20 bulk checks for LA Id 201 with 20,000 checks in each (will be deleted later)

Testing results

With the current code

<img width="875" height="225" alt="image" src="https://github.com/user-attachments/assets/54408f52-5ba7-47a2-89b8-247ce8b642e2" />

With code in PR

<img width="871" height="219" alt="image" src="https://github.com/user-attachments/assets/7c435537-9f77-459f-82f8-9886e96b4dd5" />
