### PR TITLE
Elig 3199 remove writes to audit table

### DIFF
--- a/CheckYourEligibility.API.Tests/Gateways/ApplicationServiceTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/ApplicationServiceTests.cs
@@ -581,8 +581,7 @@ public class ApplicationServiceTests : TestBase.TestBase
             NationalInsuranceNumber = request.NationalInsuranceNumber,
             Type = new CheckEligibilityRequestData().Type
         };
-        var hashId = await _HashGateway.Create(processItem, status,null, ProcessEligibilityCheckSource.HO,
-            new AuditData { Type = AuditType.Check });
+        var hashId = await _HashGateway.Create(processItem, status,null, ProcessEligibilityCheckSource.HO);
     }
 
     private async Task CreateUserEstablishmentAndLa()

--- a/CheckYourEligibility.API.Tests/Gateways/HashGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/HashGatewayTests.cs
@@ -64,8 +64,7 @@ public class HashGatewayTests : TestBase.TestBase
         var dataItem = GetCheckProcessData(fsm);
 
         // Act
-        var id = await _sut.Create(dataItem, CheckEligibilityStatus.parentNotFound,null, ProcessEligibilityCheckSource.HMRC,
-            new AuditData());
+        var id = await _sut.Create(dataItem, CheckEligibilityStatus.parentNotFound,null, ProcessEligibilityCheckSource.HMRC);
         await _fakeInMemoryDb.SaveChangesAsync();
 
         var response = await _sut.Exists(dataItem);
@@ -85,8 +84,7 @@ public class HashGatewayTests : TestBase.TestBase
         var dataItem = GetCheckProcessData(wf);
 
         // Act
-        var id = await _sut.Create(dataItem, CheckEligibilityStatus.parentNotFound,null, ProcessEligibilityCheckSource.HMRC,
-            new AuditData());
+        var id = await _sut.Create(dataItem, CheckEligibilityStatus.parentNotFound,null, ProcessEligibilityCheckSource.HMRC);
         await _fakeInMemoryDb.SaveChangesAsync();
 
         var response = await _sut.Exists(dataItem);
@@ -105,8 +103,7 @@ public class HashGatewayTests : TestBase.TestBase
         var dataItem = GetCheckProcessData(fsm);
 
 
-        var id = await _sut.Create(dataItem, CheckEligibilityStatus.parentNotFound,null, ProcessEligibilityCheckSource.HMRC,
-            new AuditData());
+        var id = await _sut.Create(dataItem, CheckEligibilityStatus.parentNotFound,null, ProcessEligibilityCheckSource.HMRC);
         await _fakeInMemoryDb.SaveChangesAsync();
         var hashItem = _fakeInMemoryDb.EligibilityCheckHashes.First(x => x.EligibilityCheckHashID.Equals(id));
         hashItem.TimeStamp = hashItem.TimeStamp.AddDays(-(_hashCheckDays + 1));
@@ -130,8 +127,7 @@ public class HashGatewayTests : TestBase.TestBase
         var dataItem = GetCheckProcessData(wf);
 
 
-        var id = await _sut.Create(dataItem, CheckEligibilityStatus.parentNotFound,null, ProcessEligibilityCheckSource.HMRC,
-            new AuditData());
+        var id = await _sut.Create(dataItem, CheckEligibilityStatus.parentNotFound,null, ProcessEligibilityCheckSource.HMRC);
         await _fakeInMemoryDb.SaveChangesAsync();
         var hashItem = _fakeInMemoryDb.EligibilityCheckHashes.First(x => x.EligibilityCheckHashID.Equals(id));
         hashItem.TimeStamp = hashItem.TimeStamp.AddDays(-(_hashCheckDaysWF + 1));

--- a/CheckYourEligibility.API.Tests/Usecases/CheckEligibilityBulkUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/CheckEligibilityBulkUseCaseTests.cs
@@ -140,9 +140,6 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
                 s.PostCheck(It.IsAny<IEnumerable<IEligibilityServiceType>>(), It.IsAny<string>(), meta))
             .Callback(() => postCheckCalled.SetResult(true))
             .Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.BulkCheck, It.IsAny<string>(), null))
-            .ReturnsAsync(_fixture.Create<string>());
-
 
         // Act
         var result = await _sut.Execute(model, CheckEligibilityType.WorkingFamilies, _recordCountLimit, meta);
@@ -157,7 +154,6 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
         _mockBulkCheckGateway.Verify(s => s.CreateBulkCheck(It.IsAny<BulkCheck>()), Times.Once);
         _mockCheckGateway.Verify(
             s => s.PostCheck(It.IsAny<IEnumerable<IEligibilityServiceType>>(), It.IsAny<string>(), meta), Times.Once);
-        _mockAuditGateway.Verify(a => a.CreateAuditEntry(AuditType.BulkCheck, It.IsAny<string>(), null), Times.Once);
     }
 
     [Test]
@@ -186,9 +182,6 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
                 s.PostCheck(It.IsAny<IEnumerable<IEligibilityServiceType>>(), It.IsAny<string>(), meta))
             .Callback(() => postCheckCalled.SetResult(true))
             .Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.BulkCheck, It.IsAny<string>(), null))
-            .ReturnsAsync(_fixture.Create<string>());
-
 
         // Act
         var result = await _sut.Execute(model, CheckEligibilityType.FreeSchoolMeals, _recordCountLimit, meta);
@@ -203,7 +196,6 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
         _mockBulkCheckGateway.Verify(s => s.CreateBulkCheck(It.IsAny<BulkCheck>()), Times.Once);
         _mockCheckGateway.Verify(
             s => s.PostCheck(It.IsAny<IEnumerable<IEligibilityServiceType>>(), It.IsAny<string>(), meta), Times.Once);
-        _mockAuditGateway.Verify(a => a.CreateAuditEntry(AuditType.BulkCheck, It.IsAny<string>(), null), Times.Once);
     }
 
     [Test]
@@ -234,8 +226,6 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
                 d => ((CheckEligibilityRequestData)d.First()).NationalInsuranceNumber == nino.ToUpper()), It.IsAny<string>(), meta))
             .Callback(() => postCheckCalled.SetResult(true))
             .Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.BulkCheck, It.IsAny<string>(), null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         await _sut.Execute(model, CheckEligibilityType.FreeSchoolMeals, _recordCountLimit, meta);
@@ -302,8 +292,6 @@ public class CheckEligibilityBulkUseCaseTests : TestBase.TestBase
         _mockCheckGateway.Setup(s => s.PostCheck(It.IsAny<IEnumerable<IEligibilityServiceType>>(), It.IsAny<string>(), meta))
             .Callback(() => postCheckCalled.SetResult(true))
             .Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.BulkCheck, It.IsAny<string>(), null))
-            .ReturnsAsync("audit-id");
 
         // Act
         await _sut.Execute(model, CheckEligibilityType.FreeSchoolMeals, _recordCountLimit, meta);

--- a/CheckYourEligibility.API.Tests/Usecases/CheckEligibilityUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/CheckEligibilityUseCaseTests.cs
@@ -95,8 +95,7 @@ public class CheckEligibilityUseCaseTests : TestBase.TestBase
             .Returns(new ValidationResult());
         _mockCheckGateway.Setup(s => s.PostCheck(It.IsAny<IEligibilityServiceType>(), meta))
             .ReturnsAsync(responseData);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Check, responseData.Id, null))
-            .ReturnsAsync(_fixture.Create<string>()); // Act
+        // Act
         // The factory will convert any model to the correct type based on routeType
         // So this test should actually succeed now
         var result = await _sut.Execute(incorrectModel, CheckEligibilityType.FreeSchoolMeals, meta);
@@ -134,11 +133,6 @@ public class CheckEligibilityUseCaseTests : TestBase.TestBase
             .Setup(s => s.PostCheck(It.IsAny<IEligibilityServiceType>(),It.IsAny<CheckMetaData>()))
             .Callback<IEligibilityServiceType, CheckMetaData>((arg,metaArg) => capturedArg = arg)
             .ReturnsAsync(responseData);
-
-        _mockAuditGateway
-            .Setup(a => a.CreateAuditEntry(AuditType.Check, responseData.Id, null))
-            .ReturnsAsync(_fixture.Create<string>());
-
         // Act
         var result = await _sut.Execute(model, CheckEligibilityType.FreeSchoolMeals, meta);
 
@@ -194,8 +188,6 @@ public class CheckEligibilityUseCaseTests : TestBase.TestBase
             .Returns(new ValidationResult());
         _mockCheckGateway.Setup(s => s.PostCheck(It.IsAny<CheckEligibilityRequestWorkingFamiliesData>(),meta))
             .ReturnsAsync(responseData);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Check, checkId, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(model, CheckEligibilityType.WorkingFamilies, meta);
@@ -226,8 +218,6 @@ public class CheckEligibilityUseCaseTests : TestBase.TestBase
             .Returns(new ValidationResult());
         _mockCheckGateway.Setup(s => s.PostCheck(It.IsAny<IEligibilityServiceType>(),meta))
             .ReturnsAsync(responseData);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Check, checkId, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(model, CheckEligibilityType.FreeSchoolMeals,meta);
@@ -258,10 +248,6 @@ public class CheckEligibilityUseCaseTests : TestBase.TestBase
             .Returns(new ValidationResult());
         _mockCheckGateway.Setup(s => s.PostCheck(It.IsAny<IEligibilityServiceType>(),meta))
             .ReturnsAsync(responseData);
-
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Check, checkId, null))
-            .ReturnsAsync(_fixture.Create<string>());
-
         // Act
         await _sut.Execute(model, CheckEligibilityType.FreeSchoolMeals, meta);
 

--- a/CheckYourEligibility.API.Tests/Usecases/CleanUpEligibilityChecksUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/CleanUpEligibilityChecksUseCaseTests.cs
@@ -35,8 +35,6 @@ public class CleanUpEligibilityChecksUseCaseTests : TestBase.TestBase
     {
         // Arrange
         _mockGateway.Setup(s => s.CleanUpEligibilityChecks()).Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         await _sut.Execute();

--- a/CheckYourEligibility.API.Tests/Usecases/CleanUpRateLimitEventsUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/CleanUpRateLimitEventsUseCaseTests.cs
@@ -35,9 +35,6 @@ public class CleanUpRateLimitEventsChecksUseCaseTests : TestBase.TestBase
     {
         // Arrange
         _mockGateway.Setup(s => s.CleanUpRateLimitEvents()).Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
-
         // Act
         await _sut.Execute();
 

--- a/CheckYourEligibility.API.Tests/Usecases/CreateApplicationUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/CreateApplicationUseCaseTests.cs
@@ -122,8 +122,6 @@ public class CreateApplicationUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetLocalAuthorityIdForEstablishment(model.Data!.Establishment))
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.PostApplication(model.Data!)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, response.Id, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(model, _allowedLocalAuthorityIds);
@@ -147,9 +145,6 @@ public class CreateApplicationUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetLocalAuthorityIdForEstablishment(model.Data!.Establishment))
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.PostApplication(model.Data!)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, response.Id, null))
-            .ReturnsAsync(_fixture.Create<string>());
-
         // Act
         var result = await _sut.Execute(model, allAuthoritiesAllowed);
 

--- a/CheckYourEligibility.API.Tests/Usecases/CreateOrUpdateUserUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/CreateOrUpdateUserUseCaseTests.cs
@@ -39,8 +39,6 @@ public class CreateOrUpdateUserUseCaseTests : TestBase.TestBase
         var responseId = _fixture.Create<string>();
 
         _mockUserGateway.Setup(us => us.Create(request.Data)).ReturnsAsync(responseId);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.User, responseId, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         var expectedResponse = new UserSaveItemResponse { Data = responseId };
 

--- a/CheckYourEligibility.API.Tests/Usecases/DeleteApplicationUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/DeleteApplicationUseCaseTests.cs
@@ -44,8 +44,6 @@ public class DeleteApplicationUseCaseTests
             .ReturnsAsync(applicationLocalAuthorityId);
         _mockApplicationGateway.Setup(x => x.DeleteApplication(guid))
             .ReturnsAsync(true);
-        _mockAuditGateway.Setup(x => x.CreateAuditEntry(AuditType.Application, guid,null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         await _sut.Execute(guid, localAuthorityIds);
@@ -66,9 +64,6 @@ public class DeleteApplicationUseCaseTests
             .ReturnsAsync(applicationLocalAuthorityId);
         _mockApplicationGateway.Setup(x => x.DeleteApplication(guid))
             .ReturnsAsync(true);
-        _mockAuditGateway.Setup(x => x.CreateAuditEntry(AuditType.Application, guid,null))
-            .ReturnsAsync(_fixture.Create<string>());
-
         // Act
         await _sut.Execute(guid, localAuthorityIds);
 
@@ -171,30 +166,6 @@ public class DeleteApplicationUseCaseTests
     }
 
     [Test]
-    public void Execute_AuditGatewayThrowsException_PropagatesException()
-    {
-        // Arrange
-        var guid = _fixture.Create<string>();
-        var localAuthorityIds = new List<int> { 0 };
-        var applicationLocalAuthorityId = _fixture.Create<int>();
-        var expectedException = new Exception("Audit service error");
-
-        _mockApplicationGateway.Setup(x => x.GetLocalAuthorityIdForApplication(guid))
-            .ReturnsAsync(applicationLocalAuthorityId);
-        _mockApplicationGateway.Setup(x => x.DeleteApplication(guid))
-            .ReturnsAsync(true);
-        _mockAuditGateway.Setup(x => x.CreateAuditEntry(AuditType.Application, guid,null))
-            .ThrowsAsync(expectedException);
-
-        // Act & Assert
-        var exception = Assert.ThrowsAsync<Exception>(
-            async () => await _sut.Execute(guid, localAuthorityIds));
-
-        exception.Should().NotBeNull();
-        exception.Should().BeSameAs(expectedException);
-    }
-
-    [Test]
     public async Task Execute_ValidGuidWithMultipleLocalAuthorities_DeletesWhenOneMatches()
     {
         // Arrange
@@ -206,8 +177,6 @@ public class DeleteApplicationUseCaseTests
             .ReturnsAsync(applicationLocalAuthorityId);
         _mockApplicationGateway.Setup(x => x.DeleteApplication(guid))
             .ReturnsAsync(true);
-        _mockAuditGateway.Setup(x => x.CreateAuditEntry(AuditType.Application, guid,null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         await _sut.Execute(guid, localAuthorityIds);
@@ -216,28 +185,6 @@ public class DeleteApplicationUseCaseTests
         // Verification is handled in TearDown through VerifyAll()
     }
 
-    [Test]
-    public async Task Execute_ValidExecution_CreatesCorrectAuditEntry()
-    {
-        // Arrange
-        var guid = _fixture.Create<string>();
-        var localAuthorityIds = new List<int> { 0 };
-        var applicationLocalAuthorityId = _fixture.Create<int>();
-        var expectedAuditId = _fixture.Create<string>();
-
-        _mockApplicationGateway.Setup(x => x.GetLocalAuthorityIdForApplication(guid))
-            .ReturnsAsync(applicationLocalAuthorityId);
-        _mockApplicationGateway.Setup(x => x.DeleteApplication(guid))
-            .ReturnsAsync(true);
-        _mockAuditGateway.Setup(x => x.CreateAuditEntry(AuditType.Application, guid,null))
-            .ReturnsAsync(expectedAuditId);
-
-        // Act
-        await _sut.Execute(guid, localAuthorityIds);
-
-        // Assert
-        _mockAuditGateway.Verify(x => x.CreateAuditEntry(AuditType.Application, guid,null), Times.Once);
-    }
 
     [Test]
     public async Task Execute_CallsGatewayMethodsInCorrectOrder()
@@ -278,8 +225,6 @@ public class DeleteApplicationUseCaseTests
             .ReturnsAsync(applicationLocalAuthorityId);
         _mockApplicationGateway.Setup(x => x.DeleteApplication(stringGuid))
             .ReturnsAsync(true);
-        _mockAuditGateway.Setup(x => x.CreateAuditEntry(AuditType.Application, stringGuid, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         await _sut.Execute(stringGuid, localAuthorityIds);

--- a/CheckYourEligibility.API.Tests/Usecases/DeleteWorkingFamiliesEventUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/DeleteWorkingFamiliesEventUseCaseTests.cs
@@ -11,7 +11,6 @@ namespace CheckYourEligibility.API.Tests.UseCases;
 public class DeleteWorkingFamiliesEventUseCaseTests : TestBase.TestBase
 {
     private Mock<IWorkingFamiliesEvent> _mockGateway = null!;
-    private Mock<IAudit> _mockAuditGateway = null!;
     private Mock<ILogger<DeleteWorkingFamiliesEventUseCase>> _mockLogger = null!;
     private DeleteWorkingFamiliesEventUseCase _sut = null!;
 
@@ -21,50 +20,34 @@ public class DeleteWorkingFamiliesEventUseCaseTests : TestBase.TestBase
     public void Setup()
     {
         _mockGateway = new Mock<IWorkingFamiliesEvent>(MockBehavior.Strict);
-        _mockAuditGateway = new Mock<IAudit>(MockBehavior.Strict);
         _mockLogger = new Mock<ILogger<DeleteWorkingFamiliesEventUseCase>>(MockBehavior.Loose);
-        _sut = new DeleteWorkingFamiliesEventUseCase(_mockGateway.Object, _mockAuditGateway.Object, _mockLogger.Object);
+        _sut = new DeleteWorkingFamiliesEventUseCase(_mockGateway.Object, _mockLogger.Object);
     }
 
     [TearDown]
     public new void Teardown()
     {
         _mockGateway.VerifyAll();
-        _mockAuditGateway.VerifyAll();
     }
 
     [Test]
-    public async Task Execute_ShouldReturnTrue_WhenEventExistsAndIsDeleted()
+    public async Task Execute_ShouldDeleteEvent_Successfully()
     {
         // Arrange
         _mockGateway.Setup(g => g.DeleteWorkingFamiliesEvent(ValidHmrcId)).ReturnsAsync(true);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, ValidHmrcId, null))
-            .ReturnsAsync(string.Empty);
 
         // Act
         var result = await _sut.Execute(ValidHmrcId);
 
         // Assert
         result.Should().BeTrue();
+        _mockGateway.Verify(g => g.DeleteWorkingFamiliesEvent(ValidHmrcId), Times.Once);
     }
 
     [Test]
-    public async Task Execute_ShouldReturnFalse_WhenEventDoesNotExist()
+    public async Task Execute_ShouldReturnFalse_WhenEventNotFound()
     {
         // Arrange
-        _mockGateway.Setup(g => g.DeleteWorkingFamiliesEvent(ValidHmrcId)).ReturnsAsync(false);
-
-        // Act
-        var result = await _sut.Execute(ValidHmrcId);
-
-        // Assert
-        result.Should().BeFalse();
-    }
-
-    [Test]
-    public async Task Execute_ShouldReturnFalse_WhenEventAlreadySoftDeleted()
-    {
-        // Arrange — gateway returns false when record is already deleted (not found with IsDeleted=false)
         _mockGateway.Setup(g => g.DeleteWorkingFamiliesEvent(ValidHmrcId)).ReturnsAsync(false);
 
         // Act
@@ -104,34 +87,5 @@ public class DeleteWorkingFamiliesEventUseCaseTests : TestBase.TestBase
         act.Should().ThrowExactlyAsync<ArgumentNullException>();
     }
 
-    [Test]
-    public async Task Execute_ShouldCallAudit_WhenEventSuccessfullyDeleted()
-    {
-        // Arrange
-        var auditCalled = false;
-        _mockGateway.Setup(g => g.DeleteWorkingFamiliesEvent(ValidHmrcId)).ReturnsAsync(true);
-        _mockAuditGateway
-            .Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, ValidHmrcId, null))
-            .ReturnsAsync(string.Empty)
-            .Callback(() => auditCalled = true);
 
-        // Act
-        await _sut.Execute(ValidHmrcId);
-
-        // Assert
-        auditCalled.Should().BeTrue();
-    }
-
-    [Test]
-    public async Task Execute_ShouldNotCallAudit_WhenEventNotFound()
-    {
-        // Arrange
-        _mockGateway.Setup(g => g.DeleteWorkingFamiliesEvent(ValidHmrcId)).ReturnsAsync(false);
-
-        // Act
-        await _sut.Execute(ValidHmrcId);
-
-        // Assert — audit should NOT be called (VerifyAll on _mockAuditGateway confirms no unexpected calls)
-        _mockAuditGateway.VerifyNoOtherCalls();
-    }
 }

--- a/CheckYourEligibility.API.Tests/Usecases/GetApplicationUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/GetApplicationUseCaseTests.cs
@@ -63,8 +63,6 @@ public class GetApplicationUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetLocalAuthorityIdForApplication(guid))
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.GetApplication(guid)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid,null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(guid, allowedLocalAuthorityIds);
@@ -87,8 +85,6 @@ public class GetApplicationUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetLocalAuthorityIdForApplication(guid))
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.GetApplication(guid)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid,null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(guid, allowedLocalAuthorityIds);
@@ -110,8 +106,6 @@ public class GetApplicationUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetLocalAuthorityIdForApplication(guid))
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.GetApplication(guid)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid,null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(guid, allowedLocalAuthorityIds);
@@ -152,8 +146,6 @@ public class GetApplicationUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetLocalAuthorityIdForApplication(guid))
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.GetApplication(guid)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid,null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(guid, allowedLocalAuthorityIds);

--- a/CheckYourEligibility.API.Tests/Usecases/GetBulkUploadResultsUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/GetBulkUploadResultsUseCaseTests.cs
@@ -86,8 +86,6 @@ public class GetBulkUploadResultsUseCaseTests : TestBase.TestBase
             .ReturnsAsync(bulkCheck);
         _mockBulkCheckGateway.Setup(s => s.GetBulkCheckResults<IList<CheckEligibilityItem>>(guid))
             .ReturnsAsync(resultItems);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.CheckBulkResults, guid,null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(guid, allowedLocalAuthorityIDs);
@@ -111,39 +109,11 @@ public class GetBulkUploadResultsUseCaseTests : TestBase.TestBase
             .ReturnsAsync(bulkCheck);
         _mockBulkCheckGateway.Setup(s => s.GetBulkCheckResults<IList<CheckEligibilityItem>>(guid))
             .ReturnsAsync(resultItems);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.CheckBulkResults, guid,null))
-            .ReturnsAsync(_fixture.Create<string>());
-
         // Act
         await _sut.Execute(guid, allowedLocalAuthorityIDs);
 
         // Assert
         _mockBulkCheckGateway.Verify(s => s.GetBulkCheckResults<IList<CheckEligibilityItem>>(guid), Times.Once);
-    }
-
-    [Test]
-    public async Task Execute_calls_auditService_AuditDataGet_with_correct_parameters()
-    {
-        // Arrange
-        var guid = _fixture.Create<string>();
-        var allowedLocalAuthorityIDs = new List<int> { 201 };
-        var bulkCheck = _fixture.Create<BulkCheck>();
-        bulkCheck.LocalAuthorityID = 201;
-        
-        var resultItems = _fixture.CreateMany<CheckEligibilityItem>().ToList();
-        
-        _mockBulkCheckGateway.Setup(s => s.GetBulkCheck(guid))
-            .ReturnsAsync(bulkCheck);
-        _mockBulkCheckGateway.Setup(s => s.GetBulkCheckResults<IList<CheckEligibilityItem>>(guid))
-            .ReturnsAsync(resultItems);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.CheckBulkResults, guid,null))
-            .ReturnsAsync(_fixture.Create<string>());
-
-        // Act
-        await _sut.Execute(guid, allowedLocalAuthorityIDs);
-
-        // Assert
-        _mockAuditGateway.Verify(a => a.CreateAuditEntry(AuditType.CheckBulkResults, guid,null), Times.Once);
     }
 
     [Test]
@@ -181,9 +151,7 @@ public class GetBulkUploadResultsUseCaseTests : TestBase.TestBase
             .ReturnsAsync(bulkCheck);
         _mockBulkCheckGateway.Setup(s => s.GetBulkCheckResults<IList<CheckEligibilityItem>>(guid))
             .ReturnsAsync(resultItems);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.CheckBulkResults, guid,null))
-            .ReturnsAsync(_fixture.Create<string>());
-
+      
         // Act
         var result = await _sut.Execute(guid, allowedLocalAuthorityIDs);
 

--- a/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckItemUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckItemUseCaseTests.cs
@@ -77,8 +77,6 @@ public class GetEligibilityCheckItemUseCaseTests : TestBase.TestBase
         var type = CheckEligibilityType.None;
         var item = _fixture.Create<CheckEligibilityItem>();
         _mockCheckGateway.Setup(s => s.GetItem<CheckEligibilityItem>(guid, type, false)).ReturnsAsync(item);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Check, guid, null)).ReturnsAsync(_fixture.Create<string>());
-
         // Act
         var result = await _sut.Execute(guid, type);
 
@@ -98,8 +96,6 @@ public class GetEligibilityCheckItemUseCaseTests : TestBase.TestBase
         var type = CheckEligibilityType.FreeSchoolMeals;
         var item = _fixture.Create<CheckEligibilityItem>();
         _mockCheckGateway.Setup(s => s.GetItem<CheckEligibilityItem>(guid, type, false)).ReturnsAsync(item);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Check, guid, null)).ReturnsAsync(_fixture.Create<string>());
-
         // Act
         var result = await _sut.Execute(guid, type);
 
@@ -119,13 +115,11 @@ public class GetEligibilityCheckItemUseCaseTests : TestBase.TestBase
         var type = _fixture.Create<CheckEligibilityType>();
         var item = _fixture.Create<CheckEligibilityItem>();
         _mockCheckGateway.Setup(s => s.GetItem<CheckEligibilityItem>(guid, type, false)).ReturnsAsync(item);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Check, guid, null)).ReturnsAsync(_fixture.Create<string>());
-
         // Act
         await _sut.Execute(guid, type);
 
         // Assert
         _mockCheckGateway.Verify(s => s.GetItem<CheckEligibilityItem>(guid, type, false), Times.Once);
-        _mockAuditGateway.Verify(a => a.CreateAuditEntry(AuditType.Check, guid, null), Times.Once);
+ 
     }
 }

--- a/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckStatusUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckStatusUseCaseTests.cs
@@ -79,9 +79,7 @@ public class GetEligibilityCheckStatusUseCaseTests : TestBase.TestBase
         _mockCheckGateway.Setup(s => s.GetStatusAsync(guid, type)).ReturnsAsync((statusValue, null));
 
         var expectedStausCode = CheckEligibilityStatus.queuedForProcessing;
-        _mockAuditGateway.Setup(a =>a.CreateAuditEntry(AuditType.Check, guid, null)).ReturnsAsync(auditId);
-
-
+       
         // Act
         var result = await _sut.Execute(guid, type);
 
@@ -99,9 +97,6 @@ public class GetEligibilityCheckStatusUseCaseTests : TestBase.TestBase
         var type = _fixture.Create<CheckEligibilityType>();
         var statusValue = _fixture.Create<CheckEligibilityStatus>();
         _mockCheckGateway.Setup(s => s.GetStatusAsync(guid, type)).ReturnsAsync((statusValue, null));
-
-        _mockAuditGateway.Setup(a =>a.CreateAuditEntry(AuditType.Check, guid,null)).ReturnsAsync(_fixture.Create<string>());
-
         // Act
         await _sut.Execute(guid, type);
 

--- a/CheckYourEligibility.API.Tests/Usecases/ImportEstablishmentsUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/ImportEstablishmentsUseCaseTests.cs
@@ -55,8 +55,7 @@ public class ImportEstablishmentsUseCaseTests : TestBase.TestBase
         fileMock.Setup(f => f.ContentType).Returns("text/csv");
 
         _mockGateway.Setup(s => s.ImportEstablishments(It.IsAny<List<EstablishmentRow>>())).Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
+
 
         // Act
         await _sut.Execute(fileMock.Object);

--- a/CheckYourEligibility.API.Tests/Usecases/ImportFsmHMRCDataUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/ImportFsmHMRCDataUseCaseTests.cs
@@ -75,9 +75,7 @@ public class ImportFsmHMRCDataUseCaseTests : TestBase.TestBase
             .Returns(new MemoryStream(Encoding.UTF8.GetBytes(Resources.exampleHMRC)));
 
         _mockGateway.Setup(s => s.ImportHMRCData(It.IsAny<List<FreeSchoolMealsHMRC>>())).Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
-
+      
         // Act
         await _sut.Execute(fileMock.Object);
 

--- a/CheckYourEligibility.API.Tests/Usecases/ImportFsmHomeOfficeDataUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/ImportFsmHomeOfficeDataUseCaseTests.cs
@@ -78,8 +78,6 @@ public class ImportFsmHomeOfficeDataUseCaseTests : TestBase.TestBase
 
         _mockGateway.Setup(s => s.ImportHomeOfficeData(It.IsAny<List<FreeSchoolMealsHO>>()))
             .Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         await _sut.Execute(fileMock.Object);

--- a/CheckYourEligibility.API.Tests/Usecases/ImportMatsUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/ImportMatsUseCaseTests.cs
@@ -55,9 +55,7 @@ public class ImportMatsUseCaseTests : TestBase.TestBase
         fileMock.Setup(f => f.ContentType).Returns("text/csv");
 
         _mockGateway.Setup(s => s.ImportMats(It.IsAny<List<MatRow>>())).Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
-
+      
         // Act
         await _sut.Execute(fileMock.Object);
 

--- a/CheckYourEligibility.API.Tests/Usecases/ImportWfHMRCDataUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/ImportWfHMRCDataUseCaseTests.cs
@@ -96,8 +96,6 @@ public class ImportWfHMRCDataUseCaseTests : TestBase.TestBase
             .Returns(stream);
 
         _mockGateway.Setup(s => s.ImportWfHMRCData(It.IsAny<List<WorkingFamiliesEvent>>())).Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         await _sut.Execute(fileMock.Object);

--- a/CheckYourEligibility.API.Tests/Usecases/ProcessEligibilityCheckUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/ProcessEligibilityCheckUseCaseTests.cs
@@ -81,8 +81,6 @@ public class ProcessEligibilityCheckUseCaseTests : TestBase.TestBase
         _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, auditItemTemplate, null))
             .ReturnsAsync((statusValue, null));
 
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Check, guid, null)).ReturnsAsync(_fixture.Create<string>());
-
         // Act
         Func<Task> act = async () => await _sut.Execute(guid);
 
@@ -102,8 +100,6 @@ public class ProcessEligibilityCheckUseCaseTests : TestBase.TestBase
             .Returns(auditItemTemplate);
         _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, auditItemTemplate, null))
             .ReturnsAsync((statusValue, null));
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Check, guid, null)).ReturnsAsync(_fixture.Create<string>());
-
         // Act
         var result = await _sut.Execute(guid);
 
@@ -124,8 +120,6 @@ public class ProcessEligibilityCheckUseCaseTests : TestBase.TestBase
             .Returns(auditItemTemplate);
         _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, auditItemTemplate, null))
             .ReturnsAsync((statusValue,null));
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Check, guid, null)).ReturnsAsync(_fixture.Create<string>());
-
         // Act
         await _sut.Execute(guid);
 

--- a/CheckYourEligibility.API.Tests/Usecases/RestoreArchivedApplicationStatusTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/RestoreArchivedApplicationStatusTests.cs
@@ -45,8 +45,6 @@ public class RestoreArchivedApplicationStatusUseCaseTests
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.RestoreArchivedApplicationStatus(guid))
             .ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(guid, allowedLocalAuthorityIds);
@@ -102,8 +100,6 @@ public class RestoreArchivedApplicationStatusUseCaseTests
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.RestoreArchivedApplicationStatus(guid))
             .ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(guid, allowedLocalAuthorityIds);
@@ -125,14 +121,8 @@ public class RestoreArchivedApplicationStatusUseCaseTests
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.RestoreArchivedApplicationStatus(guid))
             .ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid, null))
-            .ReturnsAsync(_fixture.Create<string>());
-
         // Act
         var result = await _sut.Execute(guid, allowedLocalAuthorityIds);
-
-        // Assert
-        _mockAuditGateway.Verify(a => a.CreateAuditEntry(AuditType.Application, guid, null), Times.Once);
     }
 
     [Test]
@@ -147,8 +137,6 @@ public class RestoreArchivedApplicationStatusUseCaseTests
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.RestoreArchivedApplicationStatus(guid))
             .ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(guid, allowedLocalAuthorityIds);

--- a/CheckYourEligibility.API.Tests/Usecases/SearchApplicationsUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/SearchApplicationsUseCaseTests.cs
@@ -147,8 +147,7 @@ public class SearchApplicationsUseCaseTests
         var response = _fixture.Create<ApplicationSearchResponse>();
 
         _mockApplicationGateway.Setup(s => s.GetApplications(model)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
+
 
         // Act
         var result = await _sut.Execute(model, allowedLocalAuthorityIds, allowedMultiAcademyTrustIds, allowedEstablishmentIds);
@@ -235,8 +234,6 @@ public class SearchApplicationsUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetMultiAcademyTrustIdForEstablishment(establishmentId))
             .ReturnsAsync(0); // Could not find a MAT for the establishment
             _mockApplicationGateway.Setup(s => s.GetApplications(model)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(model, allowedLocalAuthorityIds, allowedMultiAcademyTrustIds, allowedEstablishmentIds);
@@ -269,8 +266,7 @@ public class SearchApplicationsUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetMultiAcademyTrustIdForEstablishment(establishmentId))
             .ReturnsAsync(multiAcademyTrustId);
         _mockApplicationGateway.Setup(s => s.GetApplications(model)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
+
 
         // Act
         var result = await _sut.Execute(model, allowedLocalAuthorityIds, allowedMultiAcademyTrustIds, allowedEstablishmentIds);
@@ -304,8 +300,6 @@ public class SearchApplicationsUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetMultiAcademyTrustIdForEstablishment(establishmentId))
             .ReturnsAsync(multiAcademyTrustIdFromEstablishment);
         _mockApplicationGateway.Setup(s => s.GetApplications(model)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(model, allowedLocalAuthorityIds, allowedMultiAcademyTrustIds, allowedEstablishmentIds);
@@ -339,8 +333,6 @@ public class SearchApplicationsUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetMultiAcademyTrustIdForEstablishment(establishmentId))
             .ReturnsAsync(0);
         _mockApplicationGateway.Setup(s => s.GetApplications(model)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(model, allowedLocalAuthorityIds, allowedMultiAcademyTrustIds, allowedEstablishmentIds);
@@ -374,8 +366,6 @@ public class SearchApplicationsUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetMultiAcademyTrustIdForEstablishment(establishmentId))
             .ReturnsAsync(multiAcademyTrustIdFromEstablishment);
         _mockApplicationGateway.Setup(s => s.GetApplications(model)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(model, allowedLocalAuthorityIds, allowedMultiAcademyTrustIds, allowedEstablishmentIds);
@@ -460,8 +450,7 @@ public class SearchApplicationsUseCaseTests
         var response = _fixture.Create<ApplicationSearchResponse>();
 
         _mockApplicationGateway.Setup(s => s.GetApplications(model)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
+
 
         // Act
         var result = await _sut.Execute(model, allowedLocalAuthorityIds, allowedMultiAcademyTrustIds, allowedEstablishmentIds);
@@ -469,6 +458,5 @@ public class SearchApplicationsUseCaseTests
         // Assert
         result.Should().Be(response);
         _mockApplicationGateway.Verify(s => s.GetApplications(model), Times.Once);
-        _mockAuditGateway.Verify(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null), Times.Once);
     }
 }

--- a/CheckYourEligibility.API.Tests/Usecases/SearchEstablishmentsUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/SearchEstablishmentsUseCaseTests.cs
@@ -39,9 +39,7 @@ public class SearchEstablishmentsUseCaseTests : TestBase.TestBase
         string mat = null;
         var establishments = _fixture.CreateMany<Establishment>().ToList();
         _mockEstablishmentSearchGateway.Setup(es => es.Search(query, la, mat)).ReturnsAsync(establishments);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Establishment, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
-
+       
         // Act
         var result = await _sut.Execute(query, la, mat);
 
@@ -59,9 +57,6 @@ public class SearchEstablishmentsUseCaseTests : TestBase.TestBase
         var establishments = new List<Establishment>();
 
         _mockEstablishmentSearchGateway.Setup(es => es.Search(query, la, mat)).ReturnsAsync(establishments);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Establishment, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
-
 
         // Act
         var result = await _sut.Execute(query, la, mat);

--- a/CheckYourEligibility.API.Tests/Usecases/SendNotificationUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/SendNotificationUseCaseTests.cs
@@ -39,8 +39,6 @@ public class SendNotificationUseCaseTests
         // Arrange
         var request = _fixture.Create<NotificationRequest>();
         _mockNotifyGateway.Setup(s => s.SendNotification(request));
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Notification, request.Data.Email, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(request);
@@ -50,39 +48,4 @@ public class SendNotificationUseCaseTests
         result.Should().BeOfType<NotificationResponse>();
     }
 
-    [Test]
-    public async Task Execute_Should_Create_Audit_Entry()
-    {
-        // Arrange
-        var request = _fixture.Create<NotificationRequest>();
-        var auditId = _fixture.Create<string>();
-
-        _mockNotifyGateway.Setup(s => s.SendNotification(request));
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Notification, request.Data.Email, null))
-            .ReturnsAsync(auditId);
-
-        // Act
-        await _sut.Execute(request);
-
-        // Assert
-        _mockAuditGateway.Verify(a => a.CreateAuditEntry(AuditType.Notification, request.Data.Email, null), Times.Once);
-    }
-
-    [Test]
-    public async Task Execute_Should_Return_NotificationResponse()
-    {
-        // Arrange
-        var request = _fixture.Create<NotificationRequest>();
-
-        _mockNotifyGateway.Setup(s => s.SendNotification(request));
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Notification, request.Data.Email, null))
-            .ReturnsAsync(_fixture.Create<string>());
-
-        // Act
-        var result = await _sut.Execute(request);
-
-        // Assert
-        result.Should().NotBeNull();
-        result.Should().BeOfType<NotificationResponse>();
-    }
 }

--- a/CheckYourEligibility.API.Tests/Usecases/UpdateApplicationUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/UpdateApplicationUseCaseTests.cs
@@ -67,8 +67,6 @@ public class UpdateApplicationUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetLocalAuthorityIdForApplication(guid))
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.UpdateApplication(guid, model.Data!)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(guid, model, allowedLocalAuthorityIds);
@@ -91,8 +89,7 @@ public class UpdateApplicationUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetLocalAuthorityIdForApplication(guid))
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.UpdateApplication(guid, model.Data!)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid, null))
-            .ReturnsAsync(_fixture.Create<string>());
+
 
         // Act
         var result = await _sut.Execute(guid, model, allowedLocalAuthorityIds);
@@ -115,8 +112,7 @@ public class UpdateApplicationUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetLocalAuthorityIdForApplication(guid))
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.UpdateApplication(guid, model.Data!)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid, null))
-            .ReturnsAsync(_fixture.Create<string>()); // Act
+       
         var result = await _sut.Execute(guid, model, allowedLocalAuthorityIds);
 
         // Assert
@@ -157,8 +153,6 @@ public class UpdateApplicationUseCaseTests
         _mockApplicationGateway.Setup(s => s.GetLocalAuthorityIdForApplication(guid))
             .ReturnsAsync(localAuthorityId);
         _mockApplicationGateway.Setup(s => s.UpdateApplication(guid, model.Data!)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid, null))
-            .ReturnsAsync(_fixture.Create<string>());
 
         // Act
         var result = await _sut.Execute(guid, model, allowedLocalAuthorityIds);
@@ -180,15 +174,10 @@ public class UpdateApplicationUseCaseTests
 
         _mockApplicationGateway.Setup(s => s.GetLocalAuthorityIdForApplication(guid))
             .ReturnsAsync(localAuthorityId);
-        _mockApplicationGateway.Setup(s => s.UpdateApplication(guid, model.Data!)).ReturnsAsync(response);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Application, guid, null))
-            .ReturnsAsync(_fixture.Create<string>());
+        _mockApplicationGateway.Setup(s => s.UpdateApplication(guid, model.Data!)).ReturnsAsync(response);      
 
         // Act
         var result = await _sut.Execute(guid, model, allowedLocalAuthorityIds);
-
-        // Assert
-        _mockAuditGateway.Verify(a => a.CreateAuditEntry(AuditType.Application, guid, null), Times.Once);
         result.Should().NotBeNull();
     }
 }

--- a/CheckYourEligibility.API.Tests/Usecases/UpdateEligibilityCheckStatusUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/UpdateEligibilityCheckStatusUseCaseTests.cs
@@ -109,9 +109,7 @@ public class UpdateEligibilityCheckStatusUseCaseTests : TestBase.TestBase
         _mockCheckGateway
             .Setup(s => s.UpdateEligibilityCheckStatus(guid, request.Data, null))
             .ReturnsAsync(responseData);
-
-
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Check, guid, null)).ReturnsAsync(_fixture.Create<string>());
+   
 
         // Act
         var result = await _sut.Execute(guid, request);
@@ -132,7 +130,7 @@ public class UpdateEligibilityCheckStatusUseCaseTests : TestBase.TestBase
             .Setup(s => s.UpdateEligibilityCheckStatus(guid, request.Data, null))
             .ReturnsAsync(responseData);
 
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Check, guid, null)).ReturnsAsync(_fixture.Create<string>());
+        
 
 
         // Act

--- a/CheckYourEligibility.API.Tests/Usecases/UpdateEstablishmentsPrivateBetaUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/UpdateEstablishmentsPrivateBetaUseCaseTests.cs
@@ -56,9 +56,7 @@ public class UpdateEstablishmentsPrivateBetaUseCaseTests : TestBase.TestBase
         fileMock.Setup(f => f.ContentType).Returns("text/csv");
 
         _mockGateway.Setup(s => s.UpdateEstablishmentsPrivateBeta(It.IsAny<List<EstablishmentPrivateBetaRow>>())).Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty,null))
-            .ReturnsAsync(_fixture.Create<string>());
-
+      
         // Act
         await _sut.Execute(fileMock.Object);
 
@@ -87,9 +85,6 @@ public class UpdateEstablishmentsPrivateBetaUseCaseTests : TestBase.TestBase
         _mockGateway.Setup(s => s.UpdateEstablishmentsPrivateBeta(It.IsAny<List<EstablishmentPrivateBetaRow>>()))
             .Callback<IEnumerable<EstablishmentPrivateBetaRow>>(data => capturedData = data.ToList())
             .Returns(Task.CompletedTask);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.Administration, string.Empty, null))
-            .ReturnsAsync(_fixture.Create<string>());
-
         // Act
         await _sut.Execute(fileMock.Object);
 

--- a/CheckYourEligibility.API.Tests/Usecases/UpsertWorkingFamiliesEventUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/UpsertWorkingFamiliesEventUseCaseTests.cs
@@ -87,8 +87,6 @@ public class UpsertWorkingFamiliesEventUseCaseTests : TestBase.TestBase
         SetupNoOverlaps();
         _mockGateway.Setup(g => g.UpsertWorkingFamiliesEvent(It.IsAny<WorkingFamiliesEvent>()))
             .ReturnsAsync((WorkingFamiliesEvent wfe) => wfe);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, HmrcId, null))
-            .ReturnsAsync(string.Empty);
 
         // Act
         var result = await _sut.Execute(HmrcId, ValidRequest);
@@ -117,9 +115,6 @@ public class UpsertWorkingFamiliesEventUseCaseTests : TestBase.TestBase
         SetupNoOverlaps();
         _mockGateway.Setup(g => g.UpsertWorkingFamiliesEvent(It.IsAny<WorkingFamiliesEvent>()))
             .ReturnsAsync((WorkingFamiliesEvent wfe) => wfe);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, HmrcId, null))
-            .ReturnsAsync(string.Empty);
-
         // Act
         var result = await _sut.Execute(HmrcId, ValidRequest);
 
@@ -137,8 +132,6 @@ public class UpsertWorkingFamiliesEventUseCaseTests : TestBase.TestBase
         SetupNoOverlaps();
         _mockGateway.Setup(g => g.UpsertWorkingFamiliesEvent(It.IsAny<WorkingFamiliesEvent>()))
             .ReturnsAsync((WorkingFamiliesEvent wfe) => wfe);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, HmrcId, null))
-            .ReturnsAsync(string.Empty);
 
         // Act
         var result = await _sut.Execute(HmrcId, ValidRequest);
@@ -166,8 +159,6 @@ public class UpsertWorkingFamiliesEventUseCaseTests : TestBase.TestBase
         SetupNoOverlaps();
         _mockGateway.Setup(g => g.UpsertWorkingFamiliesEvent(It.IsAny<WorkingFamiliesEvent>()))
             .ReturnsAsync((WorkingFamiliesEvent wfe) => wfe);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, HmrcId, null))
-            .ReturnsAsync(string.Empty);
 
         // Act
         var result = await _sut.Execute(HmrcId, ValidRequest);
@@ -185,8 +176,6 @@ public class UpsertWorkingFamiliesEventUseCaseTests : TestBase.TestBase
         SetupNoOverlaps();
         _mockGateway.Setup(g => g.UpsertWorkingFamiliesEvent(It.IsAny<WorkingFamiliesEvent>()))
             .ReturnsAsync((WorkingFamiliesEvent wfe) => wfe);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, HmrcId, null))
-            .ReturnsAsync(string.Empty);
 
         // Act
         var result = await _sut.Execute(HmrcId, ValidRequest);
@@ -206,8 +195,6 @@ public class UpsertWorkingFamiliesEventUseCaseTests : TestBase.TestBase
         SetupNoOverlaps();
         _mockGateway.Setup(g => g.UpsertWorkingFamiliesEvent(It.IsAny<WorkingFamiliesEvent>()))
             .ReturnsAsync((WorkingFamiliesEvent wfe) => wfe);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, HmrcId, null))
-            .ReturnsAsync(string.Empty);
 
         // Act
         var result = await _sut.Execute(HmrcId, ValidRequest);
@@ -227,8 +214,6 @@ public class UpsertWorkingFamiliesEventUseCaseTests : TestBase.TestBase
         SetupNoOverlaps();
         _mockGateway.Setup(g => g.UpsertWorkingFamiliesEvent(It.IsAny<WorkingFamiliesEvent>()))
             .ReturnsAsync((WorkingFamiliesEvent wfe) => wfe);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, HmrcId, null))
-            .ReturnsAsync(string.Empty);
 
         // Act
         var result = await _sut.Execute(HmrcId, ValidRequest);
@@ -261,8 +246,6 @@ public class UpsertWorkingFamiliesEventUseCaseTests : TestBase.TestBase
         SetupNoOverlaps();
         _mockGateway.Setup(g => g.UpsertWorkingFamiliesEvent(It.IsAny<WorkingFamiliesEvent>()))
             .ReturnsAsync((WorkingFamiliesEvent wfe) => wfe);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, HmrcId, null))
-            .ReturnsAsync(string.Empty);
 
         // Act
         var result = await _sut.Execute(HmrcId, requestNoPartner);
@@ -282,8 +265,6 @@ public class UpsertWorkingFamiliesEventUseCaseTests : TestBase.TestBase
         SetupNoOverlaps();
         _mockGateway.Setup(g => g.UpsertWorkingFamiliesEvent(It.IsAny<WorkingFamiliesEvent>()))
             .ReturnsAsync((WorkingFamiliesEvent wfe) => wfe);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, HmrcId, null))
-            .ReturnsAsync(string.Empty);
 
         // Act
         var result = await _sut.Execute(HmrcId, ValidRequest);
@@ -297,21 +278,23 @@ public class UpsertWorkingFamiliesEventUseCaseTests : TestBase.TestBase
     public async Task Execute_ShouldCallAudit_AfterSuccessfulUpsert()
     {
         // Arrange
-        var auditCalled = false;
         _mockGateway.Setup(g => g.GetByHMRCId(HmrcId)).ReturnsAsync((WorkingFamiliesEvent?)null);
         SetupNoOverlaps();
         _mockGateway.Setup(g => g.UpsertWorkingFamiliesEvent(It.IsAny<WorkingFamiliesEvent>()))
             .ReturnsAsync((WorkingFamiliesEvent wfe) => wfe);
-        _mockAuditGateway
-            .Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, HmrcId, null))
-            .ReturnsAsync(string.Empty)
-            .Callback(() => auditCalled = true);
 
         // Act
-        await _sut.Execute(HmrcId, ValidRequest);
+        var result = await _sut.Execute(HmrcId, ValidRequest);
 
         // Assert
-        auditCalled.Should().BeTrue();
+        result.Should().NotBeNull();
+        result.HMRCEligibilityEventId.Should().Be(HmrcId);
+
+        _mockGateway.Verify(
+            g => g.UpsertWorkingFamiliesEvent(It.Is<WorkingFamiliesEvent>(wfe =>
+                wfe.HMRCEligibilityEventId == HmrcId &&
+                wfe.EligibilityCode == ValidDern)),
+            Times.Once);
     }
 
     [Test]
@@ -323,9 +306,6 @@ public class UpsertWorkingFamiliesEventUseCaseTests : TestBase.TestBase
         SetupNoOverlaps();
         _mockGateway.Setup(g => g.UpsertWorkingFamiliesEvent(It.IsAny<WorkingFamiliesEvent>()))
             .ReturnsAsync((WorkingFamiliesEvent wfe) => wfe);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, HmrcId, null))
-            .ReturnsAsync(string.Empty);
-
         // Act
         var result = await _sut.Execute(HmrcId, ValidRequest);
 
@@ -377,9 +357,6 @@ public class UpsertWorkingFamiliesEventUseCaseTests : TestBase.TestBase
             .ReturnsAsync(new List<WorkingFamiliesEvent>());
         _mockGateway.Setup(g => g.UpsertWorkingFamiliesEvent(It.IsAny<WorkingFamiliesEvent>()))
             .ReturnsAsync((WorkingFamiliesEvent wfe) => wfe);
-        _mockAuditGateway.Setup(a => a.CreateAuditEntry(AuditType.WorkingFamilies, HmrcId, null))
-            .ReturnsAsync(string.Empty);
-
         // Act
         var result = await _sut.Execute(HmrcId, ValidRequest);
 

--- a/CheckYourEligibility.API/Adapters/DwpAdapter.cs
+++ b/CheckYourEligibility.API/Adapters/DwpAdapter.cs
@@ -297,10 +297,7 @@ public class DwpAdapter : IDwpAdapter
         citizenResponse.CAPIEndpoint = string.Empty;
         citizenResponse.Guid = string.Empty;
         citizenResponse.CAPIEndpoint = "/v2/citizens/match";
-
-        _logger.LogInformation($"Dwp before citizen token");
         string token = await GetToken();
-        _logger.LogInformation($"Dwp token " + token);
 
         try
         {

--- a/CheckYourEligibility.API/Adapters/EcsAdapter.cs
+++ b/CheckYourEligibility.API/Adapters/EcsAdapter.cs
@@ -164,7 +164,7 @@ public class EcsAdapter : IEcsAdapter
             soapMessage = soapMessage.Replace("<ns:Surname/>",
                 $"<ns:Surname>{eligibilityCheck.LastName}</ns:Surname>");
         }
-        _logger.LogInformation("ECS SOAP request generated for warm flag check.");
+        _logger.LogInformation("ECS SOAP request generated for LA:{laId}", string.IsNullOrEmpty(laId) ? EcsLAId : laId);
         return await executeEcsCheck(soapMessage);
     }
 }

--- a/CheckYourEligibility.API/Gateways/AuditGateway.cs
+++ b/CheckYourEligibility.API/Gateways/AuditGateway.cs
@@ -3,8 +3,6 @@ using CheckYourEligibility.API.Boundary.Requests;
 using CheckYourEligibility.API.Domain;
 using CheckYourEligibility.API.Domain.Enums;
 using CheckYourEligibility.API.Gateways.Interfaces;
-using DocumentFormat.OpenXml.InkML;
-using Microsoft.EntityFrameworkCore;
 
 namespace CheckYourEligibility.API.Gateways;
 
@@ -36,11 +34,7 @@ public class AuditGateway : IAudit
             var context = dbContextFactory ?? _db;
 
             await context.Audits.AddAsync(item);
-
-            // Temp logs - delete later
-            //if (dbContextFactory != null) {
-            //    Console.WriteLine(dbContextFactory.ChangeTracker.DebugView.LongView);
-            //}
+  
             await context.SaveChangesAsync();
 
             return item.AuditID;

--- a/CheckYourEligibility.API/Gateways/BulkCheckGateway.cs
+++ b/CheckYourEligibility.API/Gateways/BulkCheckGateway.cs
@@ -1,26 +1,10 @@
 ﻿// Ignore Spelling: Fsm
 
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Net;
-using System.Security.Cryptography;
-using System.Text;
-using AutoMapper;
 using Azure.Storage.Queues;
-using Azure.Storage.Queues.Models;
-using CheckYourEligibility.API.Adapters;
-using CheckYourEligibility.API.Boundary.Requests;
-using CheckYourEligibility.API.Boundary.Requests.DWP;
 using CheckYourEligibility.API.Boundary.Responses;
-using CheckYourEligibility.API.Domain;
-using CheckYourEligibility.API.Domain.Constants;
 using CheckYourEligibility.API.Domain.Enums;
-using CheckYourEligibility.API.Domain.Exceptions;
 using CheckYourEligibility.API.Gateways.Interfaces;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.IdentityModel.Tokens;
-using Newtonsoft.Json;
 using BulkCheck = CheckYourEligibility.API.Domain.BulkCheck;
 
 namespace CheckYourEligibility.API.Gateways;

--- a/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
@@ -97,12 +97,12 @@ public class CheckingEngineGateway : ICheckingEngine
                 case CheckEligibilityType.TwoYearOffer:
                 case CheckEligibilityType.EarlyYearPupilPremium:
                     {
-                        await Process_StandardCheck(guid, auditDataTemplate, result, checkData, dbContextFactory);
+                        await Process_StandardCheck(result, checkData, dbContextFactory);
                     }
                     break;
                 case CheckEligibilityType.WorkingFamilies:
                     {
-                        await Process_WorkingFamilies_StandardCheck(guid, auditDataTemplate, result, checkData, dbContextFactory);
+                        await Process_WorkingFamilies_StandardCheck(result, checkData, dbContextFactory);
                     }
                     break;
             }
@@ -271,8 +271,7 @@ public class CheckingEngineGateway : ICheckingEngine
     /// If record is not found in WorkingFamiliesEvents table - change status to 'notFound'
     /// </summary>
     /// <returns></returns>
-    private async Task Process_WorkingFamilies_StandardCheck(string guid, AuditData auditDataTemplate,
-        EligibilityCheck? result, CheckProcessData checkData, EligibilityCheckContext dbContextFactory = null)
+    private async Task Process_WorkingFamilies_StandardCheck(EligibilityCheck? result, CheckProcessData checkData, EligibilityCheckContext dbContextFactory = null)
     {
         //TODO: This should be cleaned up
         WorkingFamiliesEvent wfEvent = new WorkingFamiliesEvent();
@@ -293,7 +292,7 @@ public class CheckingEngineGateway : ICheckingEngine
         else if (_ecsAdapter.UseEcsforChecksWF == "true")
         {
             //To ensure correct LA ID is passed when using ECS for checks
-            string laId = EligibilityCheckHelper.ExtractLAIdFromScope(auditDataTemplate.scope);
+            string laId = EligibilityCheckHelper.GetOrganisationIdOFTypeLocalAuthority(result.OrganisationType, result.OrganisationID);
             SoapCheckResponse innerResult = await _ecsAdapter.EcsWFCheck(checkData, laId);
 
             result.Status = convertEcsResultStatus(innerResult, CheckEligibilityType.WorkingFamilies);
@@ -343,7 +342,7 @@ public class CheckingEngineGateway : ICheckingEngine
 
         // Create hash just with the check request data to match on post requests
         result.EligibilityCheckHashID =
-            await _hashGateway.Create(wfCheckData, result.Status, result.Tier, source, auditDataTemplate, dbContextFactory);
+            await _hashGateway.Create(wfCheckData, result.Status, result.Tier, source, dbContextFactory);
 
         var context = dbContextFactory ?? _db;
         // Now update the check data in the EligibilityCheckTable with all the neccessary fields
@@ -392,7 +391,7 @@ public class CheckingEngineGateway : ICheckingEngine
         };
 
     }
-    private async Task Process_StandardCheck(string guid, AuditData auditDataTemplate, EligibilityCheck? result,
+    private async Task Process_StandardCheck(EligibilityCheck result,
         CheckProcessData checkData, EligibilityCheckContext dbContextFactory = null)
     {
         var context = dbContextFactory ?? _db;
@@ -413,7 +412,6 @@ public class CheckingEngineGateway : ICheckingEngine
             checkTierResult = testTier;
             source = ProcessEligibilityCheckSource.TEST;
         }
-
         else
         {
 
@@ -422,7 +420,9 @@ public class CheckingEngineGateway : ICheckingEngine
 
                 var eligibilityPolicy = await GetOrganisationEligibilityPolicyAsync(result.OrganisationType, result.OrganisationID, result.Type, dbContextFactory);
                 //To ensure correct LA ID is passed when using ECS for checks
-                string localAuthorityId = EligibilityCheckHelper.ExtractLAIdFromScope(auditDataTemplate.scope);
+
+                string localAuthorityId = EligibilityCheckHelper.GetOrganisationIdOFTypeLocalAuthority(result.OrganisationType, result.OrganisationID);
+                
                 checkStatusResult = await HMRC_Check(checkData, dbContextFactory);
                 if (checkStatusResult == CheckEligibilityStatus.parentNotFound)
                 {
@@ -494,13 +494,12 @@ public class CheckingEngineGateway : ICheckingEngine
         else
         {
             result.EligibilityCheckHashID =
-               await _hashGateway.Create(checkData, checkStatusResult, result.Tier, source, auditDataTemplate, dbContextFactory);
+               await _hashGateway.Create(checkData, checkStatusResult, result.Tier, source, dbContextFactory);
 
             //If CAPI returns a different result from ECS
             // Create a record
             if (source == ProcessEligibilityCheckSource.ECS_CONFLICT)
             {
-                var organisation = await context.Audits.FirstOrDefaultAsync(a => a.TypeID == guid);
                 ECSConflict ecsConflictRecord = new()
                 {
                     CorrelationID = correlationId,
@@ -669,41 +668,44 @@ public class CheckingEngineGateway : ICheckingEngine
                 }
             }
         };
-        //check citizen
-        // if a guid empty ie the request failed then the status is updated
-
-        _logger.LogInformation($"Dwp before getting citizen");
-
         _logger.LogInformation(JsonConvert.SerializeObject(citizenRequest));
         var citizenResponse = await _dwpAdapter.GetCitizen(citizenRequest, data.Type, correlationId);
-        _logger.LogInformation($"Dwp after getting citizen");
 
         if (string.IsNullOrEmpty(citizenResponse.Guid))
         {
-            _logger.LogInformation($"Dwp after getting citizen error " + citizenResponse.CheckEligibilityStatus);
+            _logger.LogInformation("Dwp after not finding citizen ResponseStatusCode:{code}, \n" +
+                "DWPcorrelationId: {correlationId} \n" +
+                "NINO:{nino} \n" +
+                "LastName:{lastName}\n" +
+                "DateOfBirth:{dateOfBirth}", 
+                citizenResponse.CAPIResponseCode,
+                correlationId,
+                data.NationalInsuranceNumber,
+                data.LastName,
+                data.DateOfBirth);
             return citizenResponse;
         }
         // Guid returned = citizen found
         else
         {
-            _logger.LogInformation($"Dwp has valid citizen");
+            _logger.LogInformation("Dwp has valid citizen, correlationId:{correlationId}", correlationId);
 
             // Perform a benefit check
             var result = await _dwpAdapter.GetCitizenClaims(citizenResponse.Guid, DateTime.Now.AddMonths(-3).ToString("yyyy-MM-dd"),
                 DateTime.Now.ToString("yyyy-MM-dd"), data.Type, correlationId, eligibilityPolicy);
-            _logger.LogInformation($"Dwp after getting claim");
+            _logger.LogInformation("Dwp after getting claim,correlationId:{correlationId}", correlationId);
 
             if (result.CAPIResponseCode == HttpStatusCode.OK)
             {
                 result.CheckEligibilityStatus = CheckEligibilityStatus.eligible;
-                _logger.LogInformation($"Dwp is eligible");
+                _logger.LogInformation("Dwp is eligible correlationId:{correlationId}", correlationId);
 
             }
             else if (result.CAPIResponseCode == HttpStatusCode.NotFound)
             {
                 result.CheckEligibilityStatus = CheckEligibilityStatus.notEligible;
 
-                _logger.LogInformation($"Dwp is not found");
+                _logger.LogInformation("Dwp is not found correlationId:{correlationId}", correlationId);
             }
             else
             {

--- a/CheckYourEligibility.API/Gateways/HashGateway.cs
+++ b/CheckYourEligibility.API/Gateways/HashGateway.cs
@@ -1,9 +1,7 @@
-﻿using CheckYourEligibility.API.Boundary.Requests;
-using CheckYourEligibility.API.Domain;
+﻿using CheckYourEligibility.API.Domain;
 using CheckYourEligibility.API.Domain.Enums;
 using CheckYourEligibility.API.Gateways.Interfaces;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Internal;
 
 namespace CheckYourEligibility.API.Gateways;
 
@@ -57,7 +55,7 @@ public class HashGateway : IHash
     /// <returns></returns>
     /// <remarks>NOTE there is no save, Context should be saved in calling service</remarks>
     public async Task<string> Create(CheckProcessData item, CheckEligibilityStatus outcome, EligibilityTier? tier,
-        ProcessEligibilityCheckSource source, AuditData auditDataTemplate,EligibilityCheckContext dbContextFactory = null )
+        ProcessEligibilityCheckSource source,EligibilityCheckContext dbContextFactory = null )
     {
         var hash = item.GetHash();
 
@@ -74,10 +72,6 @@ public class HashGateway : IHash
         };
         var context = dbContextFactory ?? _db;
         await context.EligibilityCheckHashes.AddAsync(HashItem);
-
-        auditDataTemplate.Type = AuditType.Hash;
-        auditDataTemplate.typeId = HashItem.EligibilityCheckHashID;
-        await _audit.AuditAdd(auditDataTemplate, dbContextFactory);
         return HashItem.EligibilityCheckHashID;
     }
 }

--- a/CheckYourEligibility.API/Gateways/Interfaces/IHash.cs
+++ b/CheckYourEligibility.API/Gateways/Interfaces/IHash.cs
@@ -11,5 +11,5 @@ public interface IHash
     Task<EligibilityCheckHash?> Exists(CheckProcessData item);
 
     Task<string> Create(CheckProcessData item, CheckEligibilityStatus checkResult, EligibilityTier? tier, ProcessEligibilityCheckSource source,
-        AuditData auditDataTemplate, EligibilityCheckContext dbContextFactory = null);
+        EligibilityCheckContext dbContextFactory = null);
 }

--- a/CheckYourEligibility.API/Helpers/EligibilityCheckHelper.cs
+++ b/CheckYourEligibility.API/Helpers/EligibilityCheckHelper.cs
@@ -1,7 +1,27 @@
-﻿namespace CheckYourEligibility.API.Helpers
+﻿using CheckYourEligibility.API.Domain.Constants;
+
+namespace CheckYourEligibility.API.Helpers
 {
     public static class EligibilityCheckHelper
     {
+        /// <summary>
+        /// If oranisation is of type LA and ID is not 0
+        /// return OrganisationID
+        /// else return and empty string
+        /// </summary>
+        /// <param name="organisationType"></param>
+        /// <param name="organisationId"></param>
+        /// <returns></returns>
+        public static string GetOrganisationIdOFTypeLocalAuthority(string? organisationType, int? organisationId ) {
+
+
+            if (organisationType != OrganisationType.local_authority || organisationId is null || organisationId == 0)
+            {
+                return string.Empty;
+            }
+
+            return organisationId.Value.ToString();
+        }
         /// <summary>
         /// Extract LA Id from scope if it exists
         /// else return an empty string.

--- a/CheckYourEligibility.API/Usecases/AuthenticateUserUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/AuthenticateUserUseCase.cs
@@ -102,6 +102,7 @@ public class AuthenticateUserUseCase : IAuthenticateUserUseCase
     /// </summary>
     private async Task<JwtAuthResponse> ExecuteAuthentication(SystemUser credentials, JwtConfig jwtConfig)
     {
+        // NOTE : This will remain for now until we implement a bettet way to audit passed scopes
         await _auditGateway.CreateAuditEntry(AuditType.Client, credentials.client_id);
 
         if (!ValidateSecret(credentials.client_secret, jwtConfig.ExpectedSecret)) throw new InvalidClientException();

--- a/CheckYourEligibility.API/Usecases/CheckEligibilityBulkUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CheckEligibilityBulkUseCase.cs
@@ -124,7 +124,6 @@ public class CheckEligibilityBulkUseCase : ICheckEligibilityBulkUseCase
         };
 
         await _bulkCheckGateway.CreateBulkCheck(bulkCheck);
-        await _auditGateway.CreateAuditEntry(AuditType.BulkCheck, groupId);
 
         // Capture the data as a typed list before the request scope ends.
         // PostCheck runs in its own DI scope so it owns its DbContext and

--- a/CheckYourEligibility.API/Usecases/CheckEligibilityUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CheckEligibilityUseCase.cs
@@ -78,7 +78,6 @@ public class CheckEligibilityUseCase : ICheckEligibilityUseCase
             var response = await _checkGateway.PostCheck(modelData.Data, meta);
             if (response != null)
             {
-                await _auditGateway.CreateAuditEntry(AuditType.Check, response.Id);
                 _logger.LogInformation($"Eligibility check created with ID: {response.Id}");
                 return new CheckEligibilityResponse
                 {

--- a/CheckYourEligibility.API/Usecases/CleanUpEligibilityChecksUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CleanUpEligibilityChecksUseCase.cs
@@ -22,6 +22,5 @@ public class CleanUpEligibilityChecksUseCase : ICleanUpEligibilityChecksUseCase
     public async Task Execute()
     {
         await _gateway.CleanUpEligibilityChecks();
-        await _auditGateway.CreateAuditEntry(AuditType.Administration, string.Empty);
     }
 }

--- a/CheckYourEligibility.API/Usecases/CleanUpRateLimitEventsUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CleanUpRateLimitEventsUseCase.cs
@@ -22,6 +22,5 @@ public class CleanUpRateLimitEventsUseCase : ICleanUpRateLimitEventsUseCase
     public async Task Execute()
     {
         await _gateway.CleanUpRateLimitEvents();
-        await _auditGateway.CreateAuditEntry(AuditType.Administration, string.Empty);
     }
 }

--- a/CheckYourEligibility.API/Usecases/CreateApplicationUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CreateApplicationUseCase.cs
@@ -72,8 +72,7 @@ public class CreateApplicationUseCase : ICreateApplicationUseCase
                 "You do not have permission to create applications for this establishment's local authority");
         }
 
-        var response = await _applicationGateway.PostApplication(model.Data);
-        if (response != null) await _auditGateway.CreateAuditEntry(AuditType.Application, response.Id);
+        var response = await _applicationGateway.PostApplication(model.Data);      
 
         if (response == null)
         {

--- a/CheckYourEligibility.API/Usecases/CreateFosterFamilyUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CreateFosterFamilyUseCase.cs
@@ -45,8 +45,6 @@ public class CreateFosterFamilyUseCase : ICreateFosterFamilyUseCase
         
         var response = await _fosterFamilyGateway.PostFosterFamily(model.Data);
 
-        if (response != null) await _auditGateway.CreateAuditEntry(AuditType.FosterFamily, response.FosterCarerId.ToString());
-
         if (response == null)
         {
             throw new Exception("Failed to create foster family");

--- a/CheckYourEligibility.API/Usecases/CreateOrUpdateUserUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/CreateOrUpdateUserUseCase.cs
@@ -33,7 +33,6 @@ public class CreateOrUpdateUserUseCase : ICreateOrUpdateUserUseCase
     {
         var response = await _userGateway.Create(model.Data);
 
-        await _auditGateway.CreateAuditEntry(AuditType.User, response);
 
         return new UserSaveItemResponse { Data = response };
     }

--- a/CheckYourEligibility.API/Usecases/DeleteApplicationUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/DeleteApplicationUseCase.cs
@@ -68,7 +68,5 @@ public class DeleteApplicationUseCase : IDeleteApplicationUseCase
             throw new NotFoundException($"Application with ID {guid} not found");
         }
 
-        // Create audit entry
-        await _auditGateway.CreateAuditEntry(AuditType.Application, guid);
     }
 }

--- a/CheckYourEligibility.API/Usecases/DeleteWorkingFamiliesEventUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/DeleteWorkingFamiliesEventUseCase.cs
@@ -33,7 +33,6 @@ public class DeleteWorkingFamiliesEventUseCase : IDeleteWorkingFamiliesEventUseC
 
         if (deleted)
         {
-            await _auditGateway.CreateAuditEntry(AuditType.WorkingFamilies, hmrcId);
             var safeId = hmrcId?.Replace("\r", string.Empty).Replace("\n", string.Empty);
             _logger.LogInformation("Working families event soft-deleted for HMRC id {HMRCId}", safeId);
         }

--- a/CheckYourEligibility.API/Usecases/DeleteWorkingFamiliesEventUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/DeleteWorkingFamiliesEventUseCase.cs
@@ -11,16 +11,13 @@ public interface IDeleteWorkingFamiliesEventUseCase
 public class DeleteWorkingFamiliesEventUseCase : IDeleteWorkingFamiliesEventUseCase
 {
     private readonly IWorkingFamiliesEvent _gateway;
-    private readonly IAudit _auditGateway;
     private readonly ILogger<DeleteWorkingFamiliesEventUseCase> _logger;
 
     public DeleteWorkingFamiliesEventUseCase(
         IWorkingFamiliesEvent gateway,
-        IAudit auditGateway,
         ILogger<DeleteWorkingFamiliesEventUseCase> logger)
     {
         _gateway = gateway;
-        _auditGateway = auditGateway;
         _logger = logger;
     }
 

--- a/CheckYourEligibility.API/Usecases/GetApplicationUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetApplicationUseCase.cs
@@ -41,7 +41,6 @@ public class GetApplicationUseCase : IGetApplicationUseCase
 
         var response = await _applicationGateway.GetApplication(guid);
         if (response == null) return null!;
-        await _auditGateway.CreateAuditEntry(AuditType.Application, guid);
 
         return new ApplicationItemResponse
         {

--- a/CheckYourEligibility.API/Usecases/GetBulkUploadResultsUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetBulkUploadResultsUseCase.cs
@@ -70,8 +70,6 @@ public class GetBulkUploadResultsUseCase : IGetBulkUploadResultsUseCase
             throw new NotFoundException(guid);
         }
 
-        await _auditGateway.CreateAuditEntry(AuditType.CheckBulkResults, guid);
-
         _logger.LogInformation(
             $"Retrieved bulk upload results for group ID: {guid.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "")}");
 

--- a/CheckYourEligibility.API/Usecases/GetEligibilityCheckItemUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetEligibilityCheckItemUseCase.cs
@@ -48,8 +48,6 @@ public class GetEligibilityCheckItemUseCase : IGetEligibilityCheckItemUseCase
             throw new NotFoundException(guid);
         }
 
-        await _auditGateway.CreateAuditEntry(AuditType.Check, guid);
-
         _logger.LogInformation(
             $"Retrieved eligibility check details for ID: {guid.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "")}");
 

--- a/CheckYourEligibility.API/Usecases/GetEligibilityCheckStatusUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetEligibilityCheckStatusUseCase.cs
@@ -47,8 +47,6 @@ public class GetEligibilityCheckStatusUseCase : IGetEligibilityCheckStatusUseCas
             throw new NotFoundException(guid);
         }
 
-        await _auditGateway.CreateAuditEntry(AuditType.Check, guid);
-
         _logger.LogInformation(
             $"Retrieved eligibility check status for ID: {guid.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "")}");
 

--- a/CheckYourEligibility.API/Usecases/GetFosterFamilyUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetFosterFamilyUseCase.cs
@@ -31,7 +31,6 @@ public class GetFosterFamilyUseCase : IGetFosterFamilyUseCase
         
         if (response == null) return null!;
         
-        await _auditGateway.CreateAuditEntry(AuditType.FosterFamily, guid);
 
         return response;
     }

--- a/CheckYourEligibility.API/Usecases/ImportApplicationsUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ImportApplicationsUseCase.cs
@@ -294,7 +294,6 @@ public class ImportApplicationsUseCase : IImportApplicationsUseCase
             response.Message = "Import completed - no records to process.";
         }
 
-        await _auditGateway.CreateAuditEntry(AuditType.Administration, string.Empty);
         return response;
     }
 

--- a/CheckYourEligibility.API/Usecases/ImportEstablishmentsUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ImportEstablishmentsUseCase.cs
@@ -58,6 +58,5 @@ public class ImportEstablishmentsUseCase : IImportEstablishmentsUseCase
         }
 
         await _gateway.ImportEstablishments(DataLoad);
-        await _auditGateway.CreateAuditEntry(AuditType.Administration, string.Empty);
     }
 }

--- a/CheckYourEligibility.API/Usecases/ImportFsmHMRCDataUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ImportFsmHMRCDataUseCase.cs
@@ -63,6 +63,5 @@ public class ImportFsmHMRCDataUseCase : IImportFsmHMRCDataUseCase
         }
 
         await _gateway.ImportHMRCData(DataLoad);
-        await _auditGateway.CreateAuditEntry(AuditType.Administration, string.Empty);
     }
 }

--- a/CheckYourEligibility.API/Usecases/ImportFsmHomeOfficeDataUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ImportFsmHomeOfficeDataUseCase.cs
@@ -66,6 +66,5 @@ public class ImportFsmHomeOfficeDataUseCase : IImportFsmHomeOfficeDataUseCase
         }
 
         await _gateway.ImportHomeOfficeData(DataLoad);
-        await _auditGateway.CreateAuditEntry(AuditType.Administration, string.Empty);
     }
 }

--- a/CheckYourEligibility.API/Usecases/ImportMatsUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ImportMatsUseCase.cs
@@ -58,6 +58,5 @@ public class ImportMatsUseCase : IImportMatsUseCase
         }
 
         await _gateway.ImportMats(DataLoad);
-        await _auditGateway.CreateAuditEntry(AuditType.Administration, string.Empty);
     }
 }

--- a/CheckYourEligibility.API/Usecases/ImportWfHMRCDataUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ImportWfHMRCDataUseCase.cs
@@ -82,7 +82,6 @@ public class ImportWfHMRCDataUseCase : IImportWfHMRCDataUseCase
         }
 
         await _gateway.ImportWfHMRCData(DataLoad);
-        await _auditGateway.CreateAuditEntry(AuditType.Administration, string.Empty);
     }
 
 }

--- a/CheckYourEligibility.API/Usecases/ProcessEligibilityCheckUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ProcessEligibilityCheckUseCase.cs
@@ -44,8 +44,7 @@ public class ProcessEligibilityCheckUseCase : IProcessEligibilityCheckUseCase
                 // pass dbContext
                 var auditItemTemplate = _auditGateway.AuditDataGet(AuditType.Check, string.Empty);
                 var (status, tier) = await _checkingEngineGateway.ProcessCheckAsync(guid, auditItemTemplate, dbContextFactory);
-                await _auditGateway.CreateAuditEntry(AuditType.Check, guid, dbContextFactory);
-            
+               
             if (status == null)
             {
                 _logger.LogWarning(

--- a/CheckYourEligibility.API/Usecases/ProcessEligibilityCheckUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ProcessEligibilityCheckUseCase.cs
@@ -40,7 +40,6 @@ public class ProcessEligibilityCheckUseCase : IProcessEligibilityCheckUseCase
 
         try
         {
-           
                 // pass dbContext
                 var auditItemTemplate = _auditGateway.AuditDataGet(AuditType.Check, string.Empty);
                 var (status, tier) = await _checkingEngineGateway.ProcessCheckAsync(guid, auditItemTemplate, dbContextFactory);

--- a/CheckYourEligibility.API/Usecases/RestoreArchivedApplicationStatusUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/RestoreArchivedApplicationStatusUseCase.cs
@@ -42,8 +42,6 @@ public class RestoreArchivedApplicationStatusUseCase : IRestoreArchivedApplicati
         var response = await _applicationGateway.RestoreArchivedApplicationStatus(guid);
         if (response == null) return null;
 
-        await _auditGateway.CreateAuditEntry(AuditType.Application, guid);
-
         return new ApplicationStatusRestoreResponse
         {
             Data = response.Data

--- a/CheckYourEligibility.API/Usecases/SearchApplicationsUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/SearchApplicationsUseCase.cs
@@ -72,7 +72,6 @@ public class SearchApplicationsUseCase : ISearchApplicationsUseCase
 
         if (response == null || !response.Data.Any())
             return new ApplicationSearchResponse { Data = [], TotalPages = 0, TotalRecords = 0, Meta = new ApplicationSearchResponseMeta(){TotalPages = 0, TotalRecords = 0} };
-        await _auditGateway.CreateAuditEntry(AuditType.Administration, string.Empty);
 
         return response;
     }

--- a/CheckYourEligibility.API/Usecases/SearchEstablishmentsUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/SearchEstablishmentsUseCase.cs
@@ -27,7 +27,6 @@ public class SearchEstablishmentsUseCase : ISearchEstablishmentsUseCase
         if (query.Length < 3 || query.Length > int.MaxValue) throw new ArgumentException();
 
         var results = await _gateway.Search(query, la, mat);
-        await _auditGateway.CreateAuditEntry(AuditType.Establishment, string.Empty);
         return results ?? Enumerable.Empty<Establishment>();
     }
 }

--- a/CheckYourEligibility.API/Usecases/SendNotificationUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/SendNotificationUseCase.cs
@@ -25,7 +25,6 @@ public class SendNotificationUseCase : ISendNotificationUseCase
     {
         _gateway.SendNotification(notificationRequest);
 
-        await _auditGateway.CreateAuditEntry(AuditType.Notification, notificationRequest.Data.Email);
         return new NotificationResponse();
     }
 }

--- a/CheckYourEligibility.API/Usecases/UpdateApplicationUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/UpdateApplicationUseCase.cs
@@ -40,7 +40,6 @@ public class UpdateApplicationUseCase : IUpdateApplicationUseCase
         var response = await _applicationGateway.UpdateApplication(guid, model.Data);
         if (response == null) return null;
 
-        await _auditGateway.CreateAuditEntry(AuditType.Application, guid);
 
         return new ApplicationUpdateResponse
         {
@@ -65,8 +64,6 @@ public class UpdateApplicationUseCase : IUpdateApplicationUseCase
         if (response == null) return null;
 
         
-        await _auditGateway.CreateAuditEntry(AuditType.Application, reference);
-
         return new ApplicationUpdateResponse
         {
             Data = response.Data

--- a/CheckYourEligibility.API/Usecases/UpdateEligibilityCheckStatusUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/UpdateEligibilityCheckStatusUseCase.cs
@@ -51,8 +51,6 @@ public class UpdateEligibilityCheckStatusUseCase : IUpdateEligibilityCheckStatus
             throw new NotFoundException(guid);
         }
 
-        await _auditGateway.CreateAuditEntry(AuditType.Check, guid);
-
         _logger.LogInformation(
             $"Updated eligibility check status for ID: {guid.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "")}");
 

--- a/CheckYourEligibility.API/Usecases/UpdateEstablishmentsPrivateBetaUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/UpdateEstablishmentsPrivateBetaUseCase.cs
@@ -58,6 +58,5 @@ public class UpdateEstablishmentsPrivateBetaUseCase : IUpdateEstablishmentsPriva
         }
 
         await _gateway.UpdateEstablishmentsPrivateBeta(dataLoad);
-        await _auditGateway.CreateAuditEntry(AuditType.Administration, string.Empty);
     }
 }

--- a/CheckYourEligibility.API/Usecases/UpdateFosterFamilyUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/UpdateFosterFamilyUseCase.cs
@@ -22,8 +22,6 @@ public class UpdateFosterFamilyUseCase : IUpdateFosterFamilyUseCase
         var response = await _fosterFamilyGateway.UpdateFosterFamily(guid, model);
         if (response == null) return null;
 
-        await _auditGateway.CreateAuditEntry(AuditType.FosterFamily, guid);
-
         return response;
     }
 }

--- a/CheckYourEligibility.API/Usecases/UpsertWorkingFamiliesEventUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/UpsertWorkingFamiliesEventUseCase.cs
@@ -86,8 +86,6 @@ public class UpsertWorkingFamiliesEventUseCase : IUpsertWorkingFamiliesEventUseC
 
         var result = await _gateway.UpsertWorkingFamiliesEvent(domain);
 
-        await _auditGateway.CreateAuditEntry(AuditType.WorkingFamilies, hmrcId);
-
         var safeId = hmrcId?.Replace("\r", string.Empty).Replace("\n", string.Empty);
         _logger.LogInformation("Working families event upserted for HMRC id {HMRCId}", safeId);
 


### PR DESCRIPTION
1. Refactor: Remove audit entry creation from various use case tests
2. Removed writings to audittable that are found redundant
3. Making sure we are still sending LAID to the request body in ECS 
4. Amended logs around ECS LAId usage for QA 
5. Enriched logs in App insights for easier tracing of calls to DWP by passing the correlation id + request details if citizen is no found or if there is a a conflict.