### PR TITLE
Refactor: Remove audit data parameter from ProcessCheckAsync

### DIFF
--- a/CheckYourEligibility.API.Tests/Gateways/CheckingEngineGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/CheckingEngineGatewayTests.cs
@@ -194,7 +194,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         var request = _fixture.Create<Guid>().ToString();
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(request, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(request);
 
         // Assert
         status.Should().BeNull();
@@ -212,7 +212,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _fakeInMemoryDb.SaveChangesAsync();
 
         // Act
-        Func<Task> act = async () => await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        Func<Task> act = async () => await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         act.Should().ThrowExactlyAsync<ProcessCheckException>();
@@ -235,7 +235,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _fakeInMemoryDb.SaveChangesAsync();
 
         // Act
-        Func<Task> act = async () => await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        Func<Task> act = async () => await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         act.Should().ThrowExactlyAsync<ProcessCheckException>().Result
@@ -267,7 +267,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.parentNotFound);
@@ -303,7 +303,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, trier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, trier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.parentNotFound);
@@ -331,7 +331,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.eligible);
@@ -372,7 +372,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         //Assert
         // Should return ECS result
@@ -400,7 +400,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.notEligible);
@@ -427,7 +427,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.notEligible);
@@ -455,7 +455,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.notEligible);
@@ -484,7 +484,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.parentNotFound);
@@ -512,7 +512,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.queuedForProcessing);
@@ -542,7 +542,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.queuedForProcessing);
@@ -575,7 +575,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.eligible);
@@ -608,7 +608,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.notEligible);
@@ -650,7 +650,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
         // Assert
         status.Should().Be(checkStatus);
     }
@@ -688,7 +688,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(checkStatus);
@@ -712,7 +712,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.parentNotFound);
@@ -743,7 +743,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.eligible);
@@ -784,7 +784,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.parentNotFound);
@@ -823,7 +823,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.eligible);
@@ -856,7 +856,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.eligible);
@@ -906,7 +906,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.notEligible);
@@ -958,7 +958,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.eligible);
@@ -996,7 +996,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqEcsGateway.Setup(x => x.UseEcsforChecksWF).Returns("false");
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.notFound);
@@ -1032,7 +1032,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
         _moqEcsGateway.Setup(x => x.UseEcsforChecksWF).Returns("false");
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.notFound);
@@ -1071,7 +1071,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         var ecsSoapCheckResponse = new SoapCheckResponse { Status = "1", ErrorCode = "0", Qualifier = "", ValidityEndDate = DateTime.Today.AddDays(-1).ToString(), ValidityStartDate = DateTime.Today.AddDays(-2).ToString(), GracePeriodEndDate = DateTime.Today.AddDays(1).ToString() };
         _moqEcsGateway.Setup(x => x.EcsWFCheck(It.IsAny<CheckProcessData>(), It.IsAny<string>())).ReturnsAsync(ecsSoapCheckResponse);
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.eligible);
@@ -1109,7 +1109,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqEcsGateway.Setup(x => x.UseEcsforChecksWF).Returns("false");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.eligible);
@@ -1165,7 +1165,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqEcsGateway.Setup(x => x.UseEcsforChecksWF).Returns("false");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.eligible);
@@ -1222,7 +1222,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqEcsGateway.Setup(x => x.UseEcsforChecksWF).Returns("false");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.eligible);
@@ -1308,7 +1308,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         _moqEcsGateway.Setup(x => x.UseEcsforChecksWF).Returns("false");
 
         // Act
-        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID, _fixture.Create<AuditData>());
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.eligible);

--- a/CheckYourEligibility.API.Tests/Usecases/ProcessEligibilityCheckUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/ProcessEligibilityCheckUseCaseTests.cs
@@ -54,11 +54,8 @@ public class ProcessEligibilityCheckUseCaseTests : TestBase.TestBase
     {
         // Arrange
         var guid = _fixture.Create<string>();
-        var auditItemTemplate = _fixture.Create<AuditData>();
 
-        _mockAuditGateway.Setup(a => a.AuditDataGet(AuditType.Check, string.Empty))
-            .Returns(auditItemTemplate);
-        _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, auditItemTemplate, null))
+        _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, null))
             .ReturnsAsync(((CheckEligibilityStatus?)null,(EligibilityTier?)null));
 
         // Act
@@ -76,9 +73,7 @@ public class ProcessEligibilityCheckUseCaseTests : TestBase.TestBase
         var auditItemTemplate = _fixture.Create<AuditData>();
         var statusValue = _fixture.Create<CheckEligibilityStatus>();
 
-        _mockAuditGateway.Setup(a => a.AuditDataGet(AuditType.Check, string.Empty))
-            .Returns(auditItemTemplate);
-        _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, auditItemTemplate, null))
+        _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, null))
             .ReturnsAsync((statusValue, null));
 
         // Act
@@ -96,9 +91,7 @@ public class ProcessEligibilityCheckUseCaseTests : TestBase.TestBase
         var auditItemTemplate = _fixture.Create<AuditData>();
         var statusValue = CheckEligibilityStatus.eligible; // Updated to use a specific status
 
-        _mockAuditGateway.Setup(a => a.AuditDataGet(AuditType.Check, string.Empty))
-            .Returns(auditItemTemplate);
-        _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, auditItemTemplate, null))
+        _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, null))
             .ReturnsAsync((statusValue, null));
         // Act
         var result = await _sut.Execute(guid);
@@ -116,15 +109,13 @@ public class ProcessEligibilityCheckUseCaseTests : TestBase.TestBase
         var statusValue = _fixture.Create<CheckEligibilityStatus>();
         statusValue = CheckEligibilityStatus.eligible;
 
-        _mockAuditGateway.Setup(a => a.AuditDataGet(AuditType.Check, string.Empty))
-            .Returns(auditItemTemplate);
-        _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, auditItemTemplate, null))
+        _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, null))
             .ReturnsAsync((statusValue,null));
         // Act
         await _sut.Execute(guid);
 
         // Assert
-        _mockCheckingEngineGateway.Verify(s => s.ProcessCheckAsync(guid, auditItemTemplate, null), Times.Once);
+        _mockCheckingEngineGateway.Verify(s => s.ProcessCheckAsync(guid, null), Times.Once);
     }
 
     [Test]
@@ -133,10 +124,7 @@ public class ProcessEligibilityCheckUseCaseTests : TestBase.TestBase
         // Arrange
         var guid = _fixture.Create<string>();
         var auditItemTemplate = _fixture.Create<AuditData>();
-
-        _mockAuditGateway.Setup(a => a.AuditDataGet(AuditType.Check, string.Empty))
-            .Returns(auditItemTemplate);
-        _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, auditItemTemplate, null))
+        _mockCheckingEngineGateway.Setup(s => s.ProcessCheckAsync(guid, null))
             .ThrowsAsync(new ProcessCheckException("Test exception"));
 
         // Act

--- a/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
@@ -79,7 +79,7 @@ public class CheckingEngineGateway : ICheckingEngine
             }
         }
     }
-    public async Task<(CheckEligibilityStatus?, EligibilityTier?)> ProcessCheckAsync(string guid, AuditData auditDataTemplate, EligibilityCheckContext dbContextFactory = null)
+    public async Task<(CheckEligibilityStatus?, EligibilityTier?)> ProcessCheckAsync(string guid, EligibilityCheckContext dbContextFactory = null)
     {
         var context = dbContextFactory ?? _db;
         //TODO: This should come from the other gateway
@@ -518,9 +518,9 @@ public class CheckingEngineGateway : ICheckingEngine
                 };
                 await context.ECSConflicts.AddAsync(ecsConflictRecord);
 
-            }
-            await context.SaveChangesAsync();
+            }           
         }
+        await context.SaveChangesAsync();
 
         var processingTime = (DateTime.Now.ToUniversalTime() - result.Created.ToUniversalTime()).Seconds;
     }

--- a/CheckYourEligibility.API/Gateways/Interfaces/ICheckingEngine.cs
+++ b/CheckYourEligibility.API/Gateways/Interfaces/ICheckingEngine.cs
@@ -5,5 +5,5 @@ namespace CheckYourEligibility.API.Gateways.Interfaces;
 
 public interface ICheckingEngine
 {
-    Task<(CheckEligibilityStatus?, EligibilityTier?)> ProcessCheckAsync(string guid, AuditData? auditItem, EligibilityCheckContext dbContextFactory = null);
+    Task<(CheckEligibilityStatus?, EligibilityTier?)> ProcessCheckAsync(string guid, EligibilityCheckContext dbContextFactory = null);
 }

--- a/CheckYourEligibility.API/Usecases/ProcessEligibilityCheckUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ProcessEligibilityCheckUseCase.cs
@@ -41,8 +41,8 @@ public class ProcessEligibilityCheckUseCase : IProcessEligibilityCheckUseCase
         try
         {
                 // pass dbContext
-                var auditItemTemplate = _auditGateway.AuditDataGet(AuditType.Check, string.Empty);
-                var (status, tier) = await _checkingEngineGateway.ProcessCheckAsync(guid, auditItemTemplate, dbContextFactory);
+              
+                var (status, tier) = await _checkingEngineGateway.ProcessCheckAsync(guid, dbContextFactory);
                
             if (status == null)
             {


### PR DESCRIPTION
Previous hidden dependency posting audits hidden in the AuditGateway affected checks that error where their record was not being updated in the db .  
This changes moves the DB context to be saved in the ProcessEngingeGateway for ALL scenarios.

Refactor: Remove  forgotten audit data parameter from ProcessCheckAsync method and related tests
