### PR TITLE
Elig 3203 back end add support for application specific data to bulk checks

### DIFF
--- a/CheckYourEligibility.API.Tests/Domain/Validation/DataValidationTests.cs
+++ b/CheckYourEligibility.API.Tests/Domain/Validation/DataValidationTests.cs
@@ -53,4 +53,62 @@ public class DataValidationTests
             e => e.PropertyName.Contains("LastName"),
             because: reason);
     }
+
+    private CheckEligibilityRequestData ValidRequestWithOptionalApplicationData() =>
+    new CheckEligibilityRequestData
+    {
+        LastName = "Tester",
+        FirstName = "Alex",
+        DateOfBirth = "2000-01-01",
+        ChildFirstName = "Sam",
+        ChildLastName = "Tester",
+        ChildDateOfBirth = "2016-04-12",
+        ChildSchoolURN = "123456",
+        NationalInsuranceNumber = "AB123456C",
+        Type = CheckEligibilityType.FreeSchoolMeals
+    };
+
+    [Test]
+    public void Optional_application_fields_with_valid_values_pass_validation()
+    {
+        var result = _validator.Validate(ValidRequestWithOptionalApplicationData());
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public void ChildDateOfBirth_with_invalid_value_fails_validation()
+    {
+        var request = ValidRequestWithOptionalApplicationData();
+        request.ChildDateOfBirth = "not-a-date";
+
+        var result = _validator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.Contains("ChildDateOfBirth"));
+    }
+
+    [Test]
+    public void ChildSchoolURN_with_non_numeric_value_fails_validation()
+    {
+        var request = ValidRequestWithOptionalApplicationData();
+        request.ChildSchoolURN = "ABC123";
+
+        var result = _validator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.Contains("ChildSchoolURN"));
+    }
+
+    [Test]
+    public void ChildFirstName_with_invalid_characters_fails_validation()
+    {
+        var request = ValidRequestWithOptionalApplicationData();
+        request.ChildFirstName = "Sam#";
+
+        var result = _validator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.Contains("ChildFirstName"));
+    }
 }

--- a/CheckYourEligibility.API.Tests/Gateways/CheckEligibilityGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/CheckEligibilityGatewayTests.cs
@@ -308,6 +308,11 @@ public class CheckEligibilityGatewayTests : TestBase.TestBase
         var check = _fixture.Create<CheckEligibilityRequestData>();
         check.DateOfBirth = "1990-01-01";
         check.Type = CheckEligibilityType.FreeSchoolMeals;
+        check.FirstName = "Alex";
+        check.ChildFirstName = "Sam";
+        check.ChildLastName = "Tester";
+        check.ChildDateOfBirth = "2016-04-12";
+        check.ChildSchoolURN = "123456";
         string eligibilityEndDate = (new DateTime(DateTime.UtcNow.Year, 07, 31)).ToString("yyyy-MM-dd");
         item.CheckData = JsonConvert.SerializeObject(GetCheckProcessData(check,eligibilityEndDate));
 
@@ -323,6 +328,11 @@ public class CheckEligibilityGatewayTests : TestBase.TestBase
         response.NationalInsuranceNumber.Should().BeEquivalentTo(check.NationalInsuranceNumber);
         response.LastName.Should().BeEquivalentTo(check.LastName.ToUpper());
         response.EligibilityEndDate.Should().BeEquivalentTo(eligibilityEndDate);
+        response.FirstName.Should().BeEquivalentTo(check.FirstName);
+        response.ChildFirstName.Should().BeEquivalentTo(check.ChildFirstName);
+        response.ChildLastName.Should().BeEquivalentTo(check.ChildLastName);
+        response.ChildDateOfBirth.Should().BeEquivalentTo(check.ChildDateOfBirth);
+        response.ChildSchoolURN.Should().BeEquivalentTo(check.ChildSchoolURN);
     }
 
     [Test]
@@ -518,6 +528,11 @@ public class CheckEligibilityGatewayTests : TestBase.TestBase
         {
             DateOfBirth = request.DateOfBirth ?? "1990-01-01",
             LastName = request.LastName,
+            FirstName = request.FirstName,
+            ChildFirstName = request.ChildFirstName,
+            ChildLastName = request.ChildLastName,
+            ChildDateOfBirth = request.ChildDateOfBirth,
+            ChildSchoolURN = request.ChildSchoolURN,
             NationalAsylumSeekerServiceNumber = request.NationalAsylumSeekerServiceNumber,
             NationalInsuranceNumber = request.NationalInsuranceNumber,
             Type = request.Type,
@@ -562,6 +577,11 @@ public class CheckEligibilityGatewayTests : TestBase.TestBase
         {
             DateOfBirth = request.DateOfBirth ?? "1990-01-01",
             LastName = request.LastName,
+            FirstName = request.FirstName,
+            ChildFirstName = request.ChildFirstName,
+            ChildLastName = request.ChildLastName,
+            ChildDateOfBirth = request.ChildDateOfBirth,
+            ChildSchoolURN = request.ChildSchoolURN,
             NationalAsylumSeekerServiceNumber = request.NationalAsylumSeekerServiceNumber,
             NationalInsuranceNumber = request.NationalInsuranceNumber,
             Type = request.Type

--- a/CheckYourEligibility.API/Boundary/Requests/CheckEligibilityRequest.cs
+++ b/CheckYourEligibility.API/Boundary/Requests/CheckEligibilityRequest.cs
@@ -11,7 +11,12 @@ public class CheckEligibilityRequestDataBase : IEligibilityServiceType
     //public int? Sequence { get; set; }
 
     public string? DateOfBirth { get; set; }
+    public string? FirstName { get; set; }
     public string? LastName { get; set; }
+    public string? ChildFirstName { get; set; }
+    public string? ChildLastName { get; set; }
+    public string? ChildDateOfBirth { get; set; }
+    public string? ChildSchoolURN { get; set; }
     /// <summary>
     /// The type of eligibility check. This field is optional and determined by the endpoint path.
     /// When submitting requests, you can omit this field as the endpoint route automatically sets the correct type.

--- a/CheckYourEligibility.API/Boundary/Responses/CheckEligibilityItemResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/CheckEligibilityItemResponse.cs
@@ -18,6 +18,11 @@ public class CheckEligibilityItem : CheckEligibilityItemBase
 {
     public string? EligibilityCheckID { get; set; }
     public string LastName { get; set; }
+    public string? FirstName { get; set; }
+    public string? ChildFirstName { get; set; }
+    public string? ChildLastName { get; set; }
+    public string? ChildDateOfBirth { get; set; }
+    public string? ChildSchoolURN { get; set; }
 
     public string DateOfBirth { get; set; }
 

--- a/CheckYourEligibility.API/Domain/CheckProcessData.cs
+++ b/CheckYourEligibility.API/Domain/CheckProcessData.cs
@@ -8,6 +8,11 @@ public class CheckProcessData
 {
     public string? NationalInsuranceNumber { get; set; }
     public string? LastName { get; set; }
+    public string? FirstName { get; set; }
+    public string? ChildFirstName { get; set; }
+    public string? ChildLastName { get; set; }
+    public string? ChildDateOfBirth { get; set; }
+    public string? ChildSchoolURN { get; set; }
     public string EligibilityCode { get; set; }
     public string ValidityStartDate { get; set; }
     public string ValidityEndDate { get; set; }

--- a/CheckYourEligibility.API/Domain/Validation/CheckEligibilityRequestDataValidator.cs
+++ b/CheckYourEligibility.API/Domain/Validation/CheckEligibilityRequestDataValidator.cs
@@ -24,7 +24,42 @@ public class CheckEligibilityRequestDataValidator : AbstractValidator<IEligibili
                 RuleFor(x => ((CheckEligibilityRequestData)x).LastName)
                     .Must(DataValidation.BeAValidName)
                     .WithMessage(ValidationMessages.LastName);
-            });          
+            });
+            When(x => !string.IsNullOrEmpty(((CheckEligibilityRequestData)x).FirstName), () =>
+            {
+                RuleFor(x => ((CheckEligibilityRequestData)x).FirstName)
+                    .Must(DataValidation.BeAValidName)
+                    .WithMessage(ValidationMessages.FirstName);
+            });
+
+            When(x => !string.IsNullOrEmpty(((CheckEligibilityRequestData)x).ChildFirstName), () =>
+            {
+                RuleFor(x => ((CheckEligibilityRequestData)x).ChildFirstName)
+                    .Must(DataValidation.BeAValidName)
+                    .WithMessage(ValidationMessages.ChildFirstName);
+            });
+
+            When(x => !string.IsNullOrEmpty(((CheckEligibilityRequestData)x).ChildLastName), () =>
+            {
+                RuleFor(x => ((CheckEligibilityRequestData)x).ChildLastName)
+                    .Must(DataValidation.BeAValidName)
+                    .WithMessage(ValidationMessages.ChildLastName);
+            });
+
+            When(x => !string.IsNullOrEmpty(((CheckEligibilityRequestData)x).ChildDateOfBirth), () =>
+            {
+                RuleFor(x => ((CheckEligibilityRequestData)x).ChildDateOfBirth)
+                    .Must(DataValidation.BeAValidDate)
+                    .WithMessage(ValidationMessages.ChildDOB);
+            });
+
+            When(x => !string.IsNullOrEmpty(((CheckEligibilityRequestData)x).ChildSchoolURN), () =>
+            {
+                RuleFor(x => ((CheckEligibilityRequestData)x).ChildSchoolURN)
+                    .Must(x => int.TryParse(x, out var urn) && urn > 0)
+                    .WithMessage("Invalid Child School URN");
+            });
+
             RuleFor(x => ((CheckEligibilityRequestData)x).DateOfBirth)
                 .NotEmpty()
                 .Must(DataValidation.BeAValidDate)

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -138,6 +138,11 @@ public class CheckEligibilityGateway : ICheckEligibility
 
                                 CheckProcessData hashCheckData = JsonConvert.DeserializeObject<CheckProcessData>(firstValidCheck.CheckData);
                                 hashCheckData.ClientIdentifier = checkData.ClientIdentifier;
+                                hashCheckData.FirstName = checkData.FirstName;
+                                hashCheckData.ChildFirstName = checkData.ChildFirstName;
+                                hashCheckData.ChildLastName = checkData.ChildLastName;
+                                hashCheckData.ChildDateOfBirth = checkData.ChildDateOfBirth;
+                                hashCheckData.ChildSchoolURN = checkData.ChildSchoolURN;
                                 item.CheckData = JsonConvert.SerializeObject(hashCheckData);
                                 _logger.LogInformation($"Action: Retrieve check with HashID:{checkHashResult.EligibilityCheckHashID}, Status:Found, Attempt:{i} ");
                                 break;
@@ -169,8 +174,13 @@ public class CheckEligibilityGateway : ICheckEligibility
                         {
                             CheckProcessData hashCheckData = JsonConvert.DeserializeObject<CheckProcessData>(firstValidCheck.CheckData);
                             hashCheckData.ClientIdentifier = checkData.ClientIdentifier;
+                            hashCheckData.FirstName = checkData.FirstName;
+                            hashCheckData.ChildFirstName = checkData.ChildFirstName;
+                            hashCheckData.ChildLastName = checkData.ChildLastName;
+                            hashCheckData.ChildDateOfBirth = checkData.ChildDateOfBirth;
+                            hashCheckData.ChildSchoolURN = checkData.ChildSchoolURN;
                             item.CheckData = JsonConvert.SerializeObject(hashCheckData);
-                            _logger.LogInformation($"Action: Retrieve check with HashID:{checkHashResult.EligibilityCheckHashID}, Status:Found");
+                            _logger.LogInformation($"Action: Retrieve check with HashID:{checkHashResult.EligibilityCheckHashID}, Status:Found");                            
                         }
                     }
                     catch (Exception ex)

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -287,6 +287,11 @@ public class CheckEligibilityGateway : ICheckEligibility
                     item.NationalInsuranceNumber = CheckData.NationalInsuranceNumber;
                     item.NationalAsylumSeekerServiceNumber = CheckData.NationalAsylumSeekerServiceNumber;
                     item.LastName = CheckData.LastName;
+                    item.FirstName = CheckData.FirstName;
+                    item.ChildFirstName = CheckData.ChildFirstName;
+                    item.ChildLastName = CheckData.ChildLastName;
+                    item.ChildDateOfBirth = CheckData.ChildDateOfBirth;
+                    item.ChildSchoolURN = CheckData.ChildSchoolURN;
                     item.EligibilityEndDate = CheckData.EligibilityEndDate;
                     break;
             }
@@ -366,6 +371,11 @@ public class CheckEligibilityGateway : ICheckEligibility
                 {
                     DateOfBirth = checkItem.DateOfBirth,
                     LastName = checkItem.LastName?.ToUpper(),
+                    FirstName = checkItem.FirstName,
+                    ChildFirstName = checkItem.ChildFirstName,
+                    ChildLastName = checkItem.ChildLastName,
+                    ChildDateOfBirth = checkItem.ChildDateOfBirth,
+                    ChildSchoolURN = checkItem.ChildSchoolURN,
                     NationalAsylumSeekerServiceNumber = checkItem.NationalAsylumSeekerServiceNumber,
                     NationalInsuranceNumber = checkItem.NationalInsuranceNumber,
                     Type = type,


### PR DESCRIPTION
## Summary

Updated the FSM bulk check API to support optional application-specific fields within bulk eligibility checks.

### Changes made

* Added support for the following optional fields in FSM bulk check requests/responses:

  * `FirstName`
  * `ChildFirstName`
  * `ChildLastName`
  * `ChildDateOfBirth`
  * `ChildSchoolURN`

* Extended request/response DTOs and `CheckProcessData` to persist and return the new fields.

* Added conditional validation rules so the new fields are only validated when supplied:

  * Name validation using existing `BeAValidName`
  * Child DOB validation using existing date validation
  * Numeric validation for `ChildSchoolURN`

* Updated FSM retrieval mapping so the additional fields are returned in bulk check results.

* Updated cached/hash-result handling in `CheckEligibilityGateway` to preserve newly submitted application-specific fields when a cached eligibility result is reused.

* Added/updated automated validator and gateway tests covering:

  * valid optional application fields
  * invalid child DOB
  * invalid child school URN
  * invalid child first name
  * retrieval of stored application-specific fields

### Manual testing completed

Verified via Postman that:

* additional fields are accepted and stored
* additional fields are returned in bulk check results
* fields are omitted from responses when not supplied
* validation errors are returned for invalid optional field values
* cached/hash eligibility paths preserve the additional submitted fields
