### PR TITLE
ELIG-3232 - Implement Tier support for applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,5 +405,6 @@ tests/cypress.env.json
 /CheckYourEligibility.API/Properties/serviceDependencies.json
 /CheckYourEligibility.API/Properties/serviceDependencies.local.json
 /CheckYourEligibility.AcceptanceTests/acceptance.runsettings
-/CheckYourEligibility.API/appsettings - Copy.Development.json
 /tests/audit.txt
+/tests/cypress/screenshots/*
+/tests/results/*

--- a/CheckYourEligibility.API.Tests/Controllers/ApplicationControllerTests.cs
+++ b/CheckYourEligibility.API.Tests/Controllers/ApplicationControllerTests.cs
@@ -15,7 +15,7 @@ using Moq;
 using System.Security.Claims;
 using ValidationException = FluentValidation.ValidationException;
 
-namespace CheckYourEligibility.API.Tests;
+namespace CheckYourEligibility.API.Tests.Controllers;
 
 public class ApplicationControllerTests : TestBase.TestBase
 {

--- a/CheckYourEligibility.API.Tests/Gateways/ApplicationGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/ApplicationGatewayTests.cs
@@ -323,6 +323,7 @@ public class ApplicationGatewayTests : TestBase.TestBase
             Reference = _fixture.Create<string>().PadRight(8)[..8], // Limit length
             Type = CheckEligibilityType.FreeSchoolMeals,
             Status = Domain.Enums.ApplicationStatus.Entitled,
+            Tier =  EligibilityTier.expanded,
             ParentFirstName = _fixture.Create<string>().PadRight(20)[..20],
             ParentLastName = _fixture.Create<string>().PadRight(20)[..20],
             ParentNationalInsuranceNumber = _fixture.Create<string>().PadRight(9)[..9],

--- a/CheckYourEligibility.API.Tests/Gateways/ApplicationServiceTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/ApplicationServiceTests.cs
@@ -261,7 +261,7 @@ public class ApplicationServiceTests : TestBase.TestBase
         {
             Data = new ApplicationSearchRequestData
             {
-                Statuses = new[] { statusItem },
+                StatusDescriptions = new[] { statusItem.ToString() },
                 Establishment = Establishment.EstablishmentID
             }
         };
@@ -290,7 +290,7 @@ public class ApplicationServiceTests : TestBase.TestBase
         {
             Data = new ApplicationSearchRequestData
             {
-                Statuses = new[] { statusItem },
+                StatusDescriptions = new[] { statusItem.ToString() },
                 Establishment = Establishment.EstablishmentID,
                 LocalAuthority = Establishment.LocalAuthorityID,
                 ParentDateOfBirth = postApplicationResponse.ParentDateOfBirth,
@@ -329,7 +329,7 @@ public class ApplicationServiceTests : TestBase.TestBase
         {
             Data = new ApplicationSearchRequestData
             {
-                Statuses = new[] { statusItem },
+                StatusDescriptions = new[] { statusItem.ToString() },
                 Establishment = Establishment.EstablishmentID,
                 LocalAuthority = Establishment.LocalAuthorityID,
                 ParentDateOfBirth = postApplicationResponse.ParentDateOfBirth,
@@ -440,7 +440,7 @@ public class ApplicationServiceTests : TestBase.TestBase
             Data = new ApplicationSearchRequestData
             {
                 Establishment = Establishment.EstablishmentID,
-                Statuses = new[] { ApplicationStatus.Archived }
+                StatusDescriptions = new[] { ApplicationStatus.Archived.ToString() }
             }
         };
 
@@ -546,7 +546,7 @@ public class ApplicationServiceTests : TestBase.TestBase
         {
             Data = new ApplicationSearchRequestData
             {
-                Statuses = new[] { statusItem },
+                StatusDescriptions = new[] { statusItem.ToString() },
                 Establishment = Establishment.EstablishmentID,
                 LocalAuthority = Establishment.LocalAuthorityID,
                 MultiAcademyTrust = MultiAcademyTrust.MultiAcademyTrustID,

--- a/CheckYourEligibility.API/Boundary/Requests/ApplicationSearchRequest.cs
+++ b/CheckYourEligibility.API/Boundary/Requests/ApplicationSearchRequest.cs
@@ -27,7 +27,7 @@ public class ApplicationSearchRequestData
     public int? LocalAuthority { get; set; }
     public int? MultiAcademyTrust { get; set; }
     public int? Establishment { get; set; }
-    public IEnumerable<ApplicationStatus>? Statuses { get; set; }
+    public IEnumerable<string>? StatusDescriptions { get; set; }
     public string? ParentLastName { get; set; }
     public string? ParentNationalInsuranceNumber { get; set; }
     public string? ParentNationalAsylumSeekerServiceNumber { get; set; }

--- a/CheckYourEligibility.API/Boundary/Requests/ApplicationUpdateRequest.cs
+++ b/CheckYourEligibility.API/Boundary/Requests/ApplicationUpdateRequest.cs
@@ -1,5 +1,3 @@
-// Ignore Spelling: Fsm
-
 using CheckYourEligibility.API.Domain.Enums;
 
 namespace CheckYourEligibility.API.Boundary.Requests;
@@ -12,5 +10,8 @@ public class ApplicationUpdateRequest
 public class ApplicationUpdateData
 {
     public ApplicationStatus? Status { get; set; }
+
+    public EligibilityTier? Tier { get; set; }
+    
     public int? EstablishmentUrn { get; set; }
 }

--- a/CheckYourEligibility.API/Boundary/Responses/ApplicationResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/ApplicationResponse.cs
@@ -18,6 +18,7 @@ public class ApplicationResponse
     public string ChildLastName { get; set; }
     public string ChildDateOfBirth { get; set; }
     public string Status { get; set; }
+    public DateTime EligibilityEndDate { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public ApplicationUser User { get; set; }
     public DateTime Created { get; set; }

--- a/CheckYourEligibility.API/Boundary/Responses/ApplicationResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/ApplicationResponse.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using CheckYourEligibility.API.Domain.Enums;
+using Newtonsoft.Json;
 
 namespace CheckYourEligibility.API.Boundary.Responses;
 
@@ -18,12 +19,12 @@ public class ApplicationResponse
     public string ChildDateOfBirth { get; set; }
     public string Status { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string? Tier { get; set; } 
     public ApplicationUser User { get; set; }
     public DateTime Created { get; set; }
     public List<ApplicationEvidenceResponse>? Evidence { get; set; }
 
     public ApplicationHash? CheckOutcome { get; set; }
+    public string? Tier { get; set; }
 
     public class ApplicationEstablishment
     {
@@ -51,5 +52,6 @@ public class ApplicationResponse
     public class ApplicationHash
     {
         public string? Outcome { get; set; }
+        public string? Tier { get; set; }
     }
 }

--- a/CheckYourEligibility.API/Boundary/Responses/ApplicationUpdateResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/ApplicationUpdateResponse.cs
@@ -15,5 +15,9 @@ public class ApplicationUpdateDataResponse
 
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public string? Tier { get; set; }
+
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public DateTime? EligibilityEndDate { get; set; }
+
     public int? EstablishmentUrn { get; set; }
 }

--- a/CheckYourEligibility.API/Domain/Application.cs
+++ b/CheckYourEligibility.API/Domain/Application.cs
@@ -49,6 +49,9 @@ public class Application
     public string? UserId { get; set; }
     public virtual EligibilityCheckHash EligibilityCheckHash { get; set; }
     public string? EligibilityCheckHashID { get; set; }
+    
+    [Column(TypeName = "nvarchar(50)")]
+    public EligibilityTier? Tier { get; set; }
 
     [Column(TypeName = "varchar(1000)")] public string ParentEmail { get; set; }
     public virtual ICollection<ApplicationEvidence> Evidence { get; set; } = new List<ApplicationEvidence>();

--- a/CheckYourEligibility.API/Factories/MappingProfile.cs
+++ b/CheckYourEligibility.API/Factories/MappingProfile.cs
@@ -53,6 +53,7 @@ public class MappingProfile : Profile
             .ForMember(x => x.ChildDateOfBirth, y => y.MapFrom(z => z.ChildDateOfBirth.ToString("yyyy-MM-dd")))
             .ForMember(x => x.Status, y => y.MapFrom(z => z.Status.ToString()))
             .ForMember(x => x.Evidence, y => y.MapFrom(z => z.Evidence))
+            .ForMember(x => x.Tier, y => y.MapFrom(z => z.Tier.ToString()))
             .ReverseMap();
 
         CreateMap<Establishment, ApplicationEstablishment>()

--- a/CheckYourEligibility.API/Gateways/ApplicationGateway.cs
+++ b/CheckYourEligibility.API/Gateways/ApplicationGateway.cs
@@ -7,6 +7,7 @@ using CheckYourEligibility.API.Domain;
 using CheckYourEligibility.API.Domain.Enums;
 using CheckYourEligibility.API.Domain.Exceptions;
 using CheckYourEligibility.API.Gateways.Interfaces;
+using CheckYourEligibility.API.Helpers;
 using Microsoft.EntityFrameworkCore;
 using System.Globalization;
 using ApplicationEvidence = CheckYourEligibility.API.Domain.ApplicationEvidence;
@@ -194,12 +195,31 @@ public class ApplicationGateway : IApplication
             {
                 result.Status = data.Status;
                 await AddStatusHistory(result, result.Status.Value);
+
+                // If status is updated to Entitled/ReviewedEntitled, calculate and set EligibilityEndDate
+                if (data.Status == ApplicationStatus.Entitled || data.Status == ApplicationStatus.ReviewedEntitled)
+                {
+                    result.EligibilityEndDate = EligibilityCheckHelper.GetEligibilityEndDateFSM(result.Created);
+                }
+            }
+
+            if (data.Tier.HasValue)
+            {
+                result.Tier = data.Tier;
             }
 
             result.Updated = DateTime.UtcNow;
             var updates = await _db.SaveChangesAsync();
             return new ApplicationUpdateResponse
-            { Data = new ApplicationUpdateDataResponse { Status = result.Status?.ToString(), EstablishmentUrn = data.EstablishmentUrn } };
+            {
+                Data = new ApplicationUpdateDataResponse
+                {
+                    Status = result.Status?.ToString(),
+                    Tier = result.Tier?.ToString(),
+                    EligibilityEndDate = result.EligibilityEndDate,
+                    EstablishmentUrn = data.EstablishmentUrn
+                }
+            };
         }
 
         return null;

--- a/CheckYourEligibility.API/Gateways/ApplicationGateway.cs
+++ b/CheckYourEligibility.API/Gateways/ApplicationGateway.cs
@@ -55,6 +55,7 @@ public class ApplicationGateway : IApplication
                 item.Status = ApplicationStatus.Entitled;
             else
                 item.Status = ApplicationStatus.SentForReview;
+            item.Tier = hashCheck.Tier;
 
             try
             {
@@ -85,7 +86,7 @@ public class ApplicationGateway : IApplication
 
             var saved = _db.Applications
                 .First(x => x.ApplicationID == item.ApplicationID);
-            
+
             return await GetApplication(saved.ApplicationID);
         }
         catch (Exception ex)
@@ -111,7 +112,11 @@ public class ApplicationGateway : IApplication
         {
             var item = _mapper.Map<ApplicationResponse>(result);
             item.CheckOutcome = new ApplicationResponse.ApplicationHash
-            { Outcome = result.EligibilityCheckHash?.Outcome.ToString() };
+            {
+                Outcome = result.EligibilityCheckHash?.Outcome.ToString(),
+                Tier = result.EligibilityCheckHash?.Tier.ToString()
+            };
+            item.Tier = result.Tier?.ToString();
             return item;
         }
 
@@ -120,17 +125,18 @@ public class ApplicationGateway : IApplication
 
     public async Task<ApplicationSearchResponse> GetApplications(ApplicationSearchRequest model)
     {
-        IQueryable<Application> query;
+        IQueryable<Application> query = _db.Applications;
 
-        if (model.Data.Statuses != null && model.Data.Statuses.Any())
+        if (model.Data.StatusDescriptions != null && model.Data.StatusDescriptions.Any())
         {
-            query = _db.Applications.Where(a => model.Data.Statuses.Contains(a.Status.Value));
+            var statusValuesOnly = model.Data.StatusDescriptions.Where(x => !x.Contains('.')).ToList();
+            var statusAndTiers = model.Data.StatusDescriptions.Where(x => x.Contains('.')).ToList();
+            query = query.Where(a =>
+                statusValuesOnly.Contains(a.Status.Value.ToString())
+                || statusAndTiers.Contains(a.Status.Value.ToString() + "." + a.Tier.Value.ToString())
+            );
         }
-        else 
-        { 
-            query = _db.Applications; 
-        }
-            
+
         // Apply other filters
         query = ApplyAdditionalFilters(query, model);
 
@@ -150,6 +156,7 @@ public class ApplicationGateway : IApplication
             .ThenInclude(x => x.LocalAuthority)
             .Include(x => x.User)
             .Include(x => x.Evidence)
+            .Include(x => x.EligibilityCheckHash)
             .ToListAsync();
 
 
@@ -192,7 +199,7 @@ public class ApplicationGateway : IApplication
             result.Updated = DateTime.UtcNow;
             var updates = await _db.SaveChangesAsync();
             return new ApplicationUpdateResponse
-                { Data = new ApplicationUpdateDataResponse { Status = result.Status?.ToString(), EstablishmentUrn = data.EstablishmentUrn } };
+            { Data = new ApplicationUpdateDataResponse { Status = result.Status?.ToString(), EstablishmentUrn = data.EstablishmentUrn } };
         }
 
         return null;
@@ -222,7 +229,7 @@ public class ApplicationGateway : IApplication
             result.Updated = DateTime.UtcNow;
             var updates = await _db.SaveChangesAsync();
             return new ApplicationUpdateResponse
-                { Data = new ApplicationUpdateDataResponse { Status = result.Status?.ToString(), EstablishmentUrn = data.EstablishmentUrn } };
+            { Data = new ApplicationUpdateDataResponse { Status = result.Status?.ToString(), EstablishmentUrn = data.EstablishmentUrn } };
         }
 
         return null;

--- a/CheckYourEligibility.API/Migrations/20260610135936_Add_Applications_Tier.Designer.cs
+++ b/CheckYourEligibility.API/Migrations/20260610135936_Add_Applications_Tier.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CheckYourEligibility.API.Migrations
 {
     [DbContext(typeof(EligibilityCheckContext))]
-    partial class EligibilityCheckContextModelSnapshot : ModelSnapshot
+    [Migration("20260610135936_Add_Applications_Tier")]
+    partial class Add_Applications_Tier
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CheckYourEligibility.API/Migrations/20260610135936_Add_Applications_Tier.cs
+++ b/CheckYourEligibility.API/Migrations/20260610135936_Add_Applications_Tier.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CheckYourEligibility.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Applications_Tier : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Tier",
+                table: "Applications",
+                type: "nvarchar(50)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Tier",
+                table: "Applications");
+        }
+    }
+}

--- a/tests/cypress/API/04 - Application/GetApplication.cy.ts
+++ b/tests/cypress/API/04 - Application/GetApplication.cy.ts
@@ -20,10 +20,11 @@ describe('GET eligibility soft check by Guid', () => {
             cy.apiRequest('POST', 'check/free-school-meals', requestBody, token).then((response) => {
                 cy.verifyApiResponseCode(response, 202);
                 cy.apiRequest('POST', '/user', validUserRequestBody(), token).then((response) => {
-                    validApplicationRequest.Data.UserId = response.Data;
-                    cy.wait(60000);
+                    validApplicationRequest.Data.UserId = response.Data;                
+                    cy.wait(5000);
 
                     //Make post request for eligibility check
+                    cy.log(JSON.stringify(validApplicationRequest));
                     cy.apiRequest('POST', 'application', validApplicationRequest, token).then((response) => {
                         cy.verifyApiResponseCode(response, 201);
                         //extract Guid

--- a/tests/cypress/API/04 - Application/PostApplication.cy.ts
+++ b/tests/cypress/API/04 - Application/PostApplication.cy.ts
@@ -11,7 +11,7 @@ describe('Verify POST application responses', () => {
                 cy.verifyApiResponseCode(response, 202);
                 cy.apiRequest('POST', '/user', validUserRequestBody(), token).then((response) => {
                     validBaseApplicationRequest.Data.UserId = response.Data;
-                    cy.wait(60000);
+                    cy.wait(5000);
 
                     //Make post request for eligibility check
                     cy.apiRequest('POST', 'application', validBaseApplicationRequest, token).then((response) => {

--- a/tests/cypress/API/04 - Application/SearchApplication.cy.ts
+++ b/tests/cypress/API/04 - Application/SearchApplication.cy.ts
@@ -46,6 +46,7 @@ describe('Search Application', () => {
             childLastName: "sdf",
             childDateOfBirth: "2001-01-01",
             status: "Open",
+            tier: "targeted",
             user: null
         }
     ];

--- a/tests/cypress/API/04 - Application/UpdateApplicationStatus.cy.ts
+++ b/tests/cypress/API/04 - Application/UpdateApplicationStatus.cy.ts
@@ -15,7 +15,7 @@ describe('Update Application Status', () => {
               cy.verifyApiResponseCode(response, 202);
               cy.apiRequest('POST', '/user', validUserRequestBody(), token).then((response) => {
                   validBaseApplicationRequest.Data.UserId = response.Data;
-                  cy.wait(60000);
+                  cy.wait(5000);
 
                   cy.apiRequest('POST', 'application', validBaseApplicationRequest, token).then((response) => {
                       // Assert the status and statusText

--- a/tests/cypress/API/04 - Application/UpdateApplicationStatusByReference.cy.ts
+++ b/tests/cypress/API/04 - Application/UpdateApplicationStatusByReference.cy.ts
@@ -15,7 +15,7 @@ describe('Update Application Status By Reference', () => {
               cy.verifyApiResponseCode(response, 202);
               cy.apiRequest('POST', '/user', validUserRequestBody(), token).then((response) => {
                   validBaseApplicationRequest.Data.UserId = response.Data;
-                  cy.wait(60000);
+                  cy.wait(5000);
 
                   cy.apiRequest('POST', 'application', validBaseApplicationRequest, token).then((response) => {
                       // Assert the status and statusText

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -376,7 +376,7 @@ Cypress.Commands.add('verifyPostApplicationResponse', (response, requestData) =>
   expect(responseData).to.have.property('childLastName', requestData.Data.ChildLastName);
   expect(responseData).to.have.property('childDateOfBirth', requestData.Data.ChildDateOfBirth);
   expect(responseData).to.have.property('status');
-  expect(responseData).to.have.property('user');
+  expect(responseData).to.have.property('tier');
   expect(responseData).to.have.property('created');
   expect(responseData).to.have.property('evidence');
   expect(responseLinks).to.have.property('get_Application');
@@ -417,8 +417,8 @@ Cypress.Commands.add('verifyGetApplicationResponse', (response, expectedData) =>
   expect(responseData).to.have.property('childLastName', expectedData.Data.ChildLastName);
   expect(responseData).to.have.property('childDateOfBirth', expectedData.Data.ChildDateOfBirth);
   expect(responseData).to.have.property('status');
-  expect(responseData).to.have.property('user');
   expect(responseData).to.have.property('created');
+  expect(responseData).to.have.property('tier');
   expect(responseData).to.have.property('evidence');
   expect(responseData).to.have.property('checkOutcome');
 
@@ -501,6 +501,7 @@ Cypress.Commands.add('verifyApplicationSearchResponse', (response, expectedDataA
   expect(expectedData).to.have.property('childLastName', expectedData.childLastName);
   expect(expectedData).to.have.property('childDateOfBirth', expectedData.childDateOfBirth);
   expect(expectedData).to.have.property('status', expectedData.status);
+  expect(expectedData).to.have.property('tier', expectedData.tier);
   expect(expectedData).to.have.property('user', expectedData.user);
 
 });

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -359,7 +359,7 @@ Cypress.Commands.add('verifyPostApplicationResponse', (response, requestData) =>
 
   // Verfiy total number of elements
   const totalElements = Object.keys(responseData).length + Object.keys(responseLinks).length;
-  cy.verifyTotalElements(totalElements, 18);
+  cy.verifyTotalElements(totalElements, 19);
 
   // Assertions to verify response data matches request data
   expect(responseData).to.have.property('id');
@@ -397,7 +397,7 @@ Cypress.Commands.add('verifyGetApplicationResponse', (response, expectedData) =>
     Object.keys(responseData.establishment).length +
     Object.keys(responseData.establishment.localAuthority).length +
     Object.keys(responseLinks).length;
-  cy.verifyTotalElements(totalElements, 23);
+  cy.verifyTotalElements(totalElements, 24);
 
   expect(responseData).to.have.property('id');
   expect(responseData).to.have.property('reference');

--- a/tests/cypress/support/interfaces.ts
+++ b/tests/cypress/support/interfaces.ts
@@ -24,6 +24,7 @@ export interface LocalAuthority {
     childLastName: string;
     childDateOfBirth: string;
     status: string;
+    tier: string;
     user: any;
   }
   

--- a/tests/cypress/support/requestBodies.ts
+++ b/tests/cypress/support/requestBodies.ts
@@ -105,7 +105,7 @@ export function noNIAndNASSNRequestBody() {
 export function validApplicationSupportRequestBody() {
   return {
     data: {
-      nationalInsuranceNumber: "NN668767B",
+      nationalInsuranceNumber: "NE668767B",
       lastName: Cypress.env("lastName"),
       // lastName: "TESTER",
       dateOfBirth: "1967-03-07",
@@ -131,7 +131,7 @@ export function validApplicationRequestBody() {
       ParentFirstName: "Lebb",
       ParentLastName: Cypress.env("lastName"),
       // ParentLastName: "TESTER",
-      ParentNationalInsuranceNumber: "NN668767B",
+      ParentNationalInsuranceNumber: "NE668767B",
       ParentNationalAsylumSeekerServiceNumber: null,
       ParentDateOfBirth: "1967-03-07",
       ChildFirstName: "Alexa",


### PR DESCRIPTION
- Add nullable Tier field to Applications table to store tier value from soft-check
- Populate Tier for existing records from their linked hash record
- Expose the Tier field on the ApplicationResponse
- Allow the application/search feature to accept mixed status + tier values for filtering
- Add logic to populate and return EligibilityEndDate for applications