### PR TITLE
Elig 3303 post admin import establishments resets local authority policy columns to 0

### DIFF
--- a/CheckYourEligibility.API.Tests/Gateways/AdministrationGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/AdministrationGatewayTests.cs
@@ -155,6 +155,43 @@ public class AdministrationGatewayTests : TestBase.TestBase
         Assert.Pass();
     }
 
+    [Test]
+    public void Given_ImportEstablishments_When_LocalAuthorityExists_Should_PreservePolicySettings()
+    {
+        var data = _fixture.CreateMany<EstablishmentRow>(1).ToList();
+
+        var row = data.First();
+        row.LaCode = 213;
+        row.LaName = "Westminster";
+
+        var existingLocalAuthority = new LocalAuthority
+        {
+            LocalAuthorityID = 213,
+            LaName = "Westminster",
+            SchoolCanReviewEvidence = true,
+            EarlyYearsPupilPremiumPolicyID = 2,
+            FreeSchoolMealsPolicyID = 4,
+            TwoYearPolicyID = 3
+        };
+
+        _fakeInMemoryDb.LocalAuthorities.Add(existingLocalAuthority);
+        _fakeInMemoryDb.SaveChanges();
+
+        // Act
+        _sut.ImportEstablishments(data);
+
+        // Assert
+        var localAuthority = _fakeInMemoryDb.LocalAuthorities.Single(x => x.LocalAuthorityID == 213);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(localAuthority.SchoolCanReviewEvidence, Is.True);
+            Assert.That(localAuthority.EarlyYearsPupilPremiumPolicyID, Is.EqualTo(2));
+            Assert.That(localAuthority.FreeSchoolMealsPolicyID, Is.EqualTo(4));
+            Assert.That(localAuthority.TwoYearPolicyID, Is.EqualTo(3));
+        });
+    }
+
     /// <summary>
     ///     Calling multiple times will generate concurrency errors, which is a limitation of in memory db
     /// </summary>

--- a/CheckYourEligibility.API.Tests/Gateways/AdministrationGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/AdministrationGatewayTests.cs
@@ -23,15 +23,19 @@ public class AdministrationGatewayTests : TestBase.TestBase
     private IEligibilityCheckContext _fakeInMemoryDb;
     private IMapper _mapper;
     private AdministrationGateway _sut;
+    private static readonly InMemoryDatabaseRoot InMemoryDatabaseRoot = new();
 
     [SetUp]
     public void Setup()
     {
         var options = new DbContextOptionsBuilder<EligibilityCheckContext>()
-            .UseInMemoryDatabase("FakeInMemoryDb", new InMemoryDatabaseRoot())
+            .UseInMemoryDatabase(nameof(AdministrationGatewayTests), InMemoryDatabaseRoot)
             .Options;
 
         _fakeInMemoryDb = new EligibilityCheckContext(options);
+
+        _fakeInMemoryDb.Database.EnsureDeleted();
+        _fakeInMemoryDb.Database.EnsureCreated();
 
         var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
         _mapper = config.CreateMapper();

--- a/CheckYourEligibility.API.Tests/Gateways/RateLimiterGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/RateLimiterGatewayTests.cs
@@ -13,15 +13,19 @@ public class RateLimiterServiceTests : TestBase.TestBase
 {
     private IEligibilityCheckContext _fakeInMemoryDb;
     private RateLimitGateway _sut;
+    private static readonly InMemoryDatabaseRoot InMemoryDatabaseRoot = new();
 
     [SetUp]
     public void Setup()
     {
         var options = new DbContextOptionsBuilder<EligibilityCheckContext>()
-            .UseInMemoryDatabase("FakeInMemoryDb", new InMemoryDatabaseRoot())
+            .UseInMemoryDatabase(nameof(RateLimiterServiceTests), InMemoryDatabaseRoot)
             .Options;
 
         _fakeInMemoryDb = new EligibilityCheckContext(options);
+
+        _fakeInMemoryDb.Database.EnsureDeleted();
+        _fakeInMemoryDb.Database.EnsureCreated();
 
         var configForRLCleanUp = new Dictionary<string, string?>
         {

--- a/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
+++ b/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
@@ -167,7 +167,21 @@ public class EligibilityCheckContext : DbContext, IEligibilityCheckContext
         try
         {
             this.BulkInsertOrUpdate(data, config =>
-            config.UpdateByProperties = new List<string> { nameof(LocalAuthority.LocalAuthorityID), nameof(LocalAuthority.LaName) });
+            {
+                config.UpdateByProperties = new List<string>
+                {
+                    nameof(LocalAuthority.LocalAuthorityID),
+                    nameof(LocalAuthority.LaName)
+                };
+
+                            config.PropertiesToExcludeOnUpdate = new List<string>
+                {
+                    nameof(LocalAuthority.SchoolCanReviewEvidence),
+                    nameof(LocalAuthority.EarlyYearsPupilPremiumPolicyID),
+                    nameof(LocalAuthority.FreeSchoolMealsPolicyID),
+                    nameof(LocalAuthority.TwoYearPolicyID)
+                };
+            });
             transaction.Commit();
         }
 

--- a/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
+++ b/CheckYourEligibility.API/Infrastructure/EligibilityCheckContext.cs
@@ -174,7 +174,7 @@ public class EligibilityCheckContext : DbContext, IEligibilityCheckContext
                     nameof(LocalAuthority.LaName)
                 };
 
-                            config.PropertiesToExcludeOnUpdate = new List<string>
+                config.PropertiesToExcludeOnUpdate = new List<string>
                 {
                     nameof(LocalAuthority.SchoolCanReviewEvidence),
                     nameof(LocalAuthority.EarlyYearsPupilPremiumPolicyID),


### PR DESCRIPTION
PR Notes

## Changes

* Updated `BulkInsertOrUpdate_LocalAuthority` to exclude LocalAuthority policy/settings fields from bulk update operations
* Added test coverage to verify policy values are preserved during establishment imports

## Root Cause

`ImportEstablishments` creates partially populated `LocalAuthority` entities containing only:

* `LocalAuthorityID`
* `LaName`

During bulk upsert, unset properties were being written back to the database as default values (`0` / `false`), unintentionally overwriting existing policy configuration.

## Validation

Manually tested against Westminster (`LocalAuthorityID = 213`) using the CSV from the Jira ticket and confirmed policy values remain unchanged after import.
