### PR TITLE
Elig 3314 returning fsm expansion values for asylum seeker nass checks

### DIFF
--- a/CheckYourEligibility.API.Tests/Gateways/CheckingEngineGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/CheckingEngineGatewayTests.cs
@@ -716,6 +716,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.parentNotFound);
+        tier.Should().BeNull();
     }
 
     [Test]
@@ -860,6 +861,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
         // Assert
         status.Should().Be(CheckEligibilityStatus.eligible);
+        tier.Should().Be(EligibilityTier.targeted);
     }
 
     [Test]

--- a/CheckYourEligibility.API.Tests/Gateways/CheckingEngineGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/CheckingEngineGatewayTests.cs
@@ -853,7 +853,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
             LastName = dataItem.LastName,
             DateOfBirth = DateTime.ParseExact(dataItem.DateOfBirth, "yyyy-MM-dd", null, DateTimeStyles.None)
         });
-        _fakeInMemoryDb.SaveChangesAsync();
+        await _fakeInMemoryDb.SaveChangesAsync();
         _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
 
         // Act

--- a/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
@@ -468,6 +468,11 @@ public class CheckingEngineGateway : ICheckingEngine
             {
                 checkStatusResult = await HO_Check(checkData, dbContextFactory);
                 source = ProcessEligibilityCheckSource.HO;
+
+                if (checkStatusResult == CheckEligibilityStatus.eligible)
+                {
+                    checkTierResult = EligibilityTier.targeted;
+                }
             }
         }
 

--- a/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
@@ -126,7 +126,7 @@ public class CheckingEngineGateway : ICheckingEngine
                 return (CheckEligibilityStatus.eligible, EligibilityTier.expanded);
 
             if (nino.StartsWith(_configuration.GetValue<string>("TestData:Outcomes:NationalInsuranceNumber:Eligible")))
-                return (CheckEligibilityStatus.eligible, null);
+                return (CheckEligibilityStatus.eligible, EligibilityTier.targeted);
             if (nino.StartsWith(
                     _configuration.GetValue<string>("TestData:Outcomes:NationalInsuranceNumber:NotEligible")))
                 return (CheckEligibilityStatus.notEligible, null);
@@ -141,7 +141,7 @@ public class CheckingEngineGateway : ICheckingEngine
         {
             nass = nass.Substring(2, 2);
             if (nass == _configuration.GetValue<string>("TestData:Outcomes:NationalAsylumSeekerServiceNumber:Eligible"))
-                return (CheckEligibilityStatus.eligible, null);
+                return (CheckEligibilityStatus.eligible, EligibilityTier.targeted);
             if (nass == _configuration.GetValue<string>(
                     "TestData:Outcomes:NationalAsylumSeekerServiceNumber:NotEligible"))
                 return (CheckEligibilityStatus.notEligible, null);

--- a/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
@@ -126,7 +126,7 @@ public class CheckingEngineGateway : ICheckingEngine
                 return (CheckEligibilityStatus.eligible, EligibilityTier.expanded);
 
             if (nino.StartsWith(_configuration.GetValue<string>("TestData:Outcomes:NationalInsuranceNumber:Eligible")))
-                return (CheckEligibilityStatus.eligible, EligibilityTier.targeted);
+                return (CheckEligibilityStatus.eligible, null);
             if (nino.StartsWith(
                     _configuration.GetValue<string>("TestData:Outcomes:NationalInsuranceNumber:NotEligible")))
                 return (CheckEligibilityStatus.notEligible, null);


### PR DESCRIPTION
Updated FSM HO/NASS eligibility processing so that successful asylum seeker checks now return `EligibilityTier.targeted` instead of a null tier value.

Changes made:

* Updated HO/NASS processing in `Process_StandardCheck` to assign `EligibilityTier.targeted` when `HO_Check` returns `eligible`
* Updated NASS test data processing to return targeted tier for eligible outcomes
* Extended HO/NASS unit tests to validate returned tier values for both eligible and parentNotFound scenarios

Result:

* Eligible NASS checks now correctly return `Eligible + Targeted`
* NASS checks can no longer return `Expanded`
* Parent not found outcomes remain unchanged
