### PR TITLE
Elig 3326 back end add batch check summary endpoint

### DIFF
--- a/CheckYourEligibility.API.Tests/Controllers/BulkCheckControllerTests.cs
+++ b/CheckYourEligibility.API.Tests/Controllers/BulkCheckControllerTests.cs
@@ -37,6 +37,7 @@ public class BulkCheckControllerTests : TestBase.TestBase
     private Mock<IUpdateEligibilityCheckStatusUseCase> _mockUpdateEligibilityCheckStatusUseCase;
     private Mock<IDeleteBulkCheckUseCase> _mockDeleteBulkCheckUseCase;
     private Mock<IGetAllBulkChecksUseCase> _mockGetAllBulkChecksUseCase;
+    private readonly Mock<IGetBulkCheckSummaryUseCase> _mockBulkCheckSummaryUseCase = new();
 
     private BulkCheckController _sut;
 
@@ -76,7 +77,8 @@ public class BulkCheckControllerTests : TestBase.TestBase
             _mockGetBulkUploadProgressUseCase.Object,
             _mockGetBulkUploadResultsUseCase.Object,
             _mockDeleteBulkCheckUseCase.Object,
-            _mockGetAllBulkChecksUseCase.Object
+            _mockGetAllBulkChecksUseCase.Object,
+            _mockBulkCheckSummaryUseCase.Object
         );
 
         // Setup default HttpContext with a Mock HttpRequest

--- a/CheckYourEligibility.API.Tests/Controllers/GetAllBulkChecksControllerTests.cs
+++ b/CheckYourEligibility.API.Tests/Controllers/GetAllBulkChecksControllerTests.cs
@@ -220,5 +220,67 @@ namespace CheckYourEligibility.API.Tests.Controllers
             // Assert
             Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
         }
+
+        [Test]
+        public async Task GetBulkCheckSummary_WhenBulkCheckExists_ReturnsOkResult()
+        {
+            // Arrange
+            var bulkCheckId = Guid.NewGuid();
+
+            var expectedResponse = new BulkCheckSummaryResponse
+            {
+                Filename = "test.csv",
+                Status = "Complete",
+                SubmittedDate = DateTime.UtcNow,
+                SubmittedBy = "test-user@test.com",
+                Outcomes = new Dictionary<string, int>
+                {
+                    { "eligible", 5 },
+                    { "eligible-targeted", 10 },
+                    { "notEligible", 2 }
+                }
+            };
+
+            _mockBulkCheckSummaryUseCase
+                .Setup(x => x.Execute(
+                    bulkCheckId,
+                    It.IsAny<IList<int>>(),
+                    It.IsAny<CheckMetaData>()))
+                .ReturnsAsync(expectedResponse);
+
+            var claims = new List<Claim>
+            {
+                new Claim("scope", "local_authority:123"),
+                new Claim(
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+                    "free-school-meals-admin:test-user@test.com")
+            };
+
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(claims))
+                }
+            };
+
+            // Act
+            var result = await _controller.GetBulkCheckSummary(bulkCheckId);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<ObjectResult>());
+
+            var objectResult = (ObjectResult)result;
+
+            Assert.That(objectResult.StatusCode, Is.EqualTo(200));
+            Assert.That(objectResult.Value, Is.InstanceOf<BulkCheckSummaryResponse>());
+
+            var response = (BulkCheckSummaryResponse)objectResult.Value!;
+
+            Assert.That(response.Filename, Is.EqualTo("test.csv"));
+            Assert.That(response.Outcomes["eligible"], Is.EqualTo(5));
+            Assert.That(response.Outcomes["eligible-targeted"], Is.EqualTo(10));
+            Assert.That(response.Outcomes["notEligible"], Is.EqualTo(2));
+        }
     }
 }

--- a/CheckYourEligibility.API.Tests/Controllers/GetAllBulkChecksControllerTests.cs
+++ b/CheckYourEligibility.API.Tests/Controllers/GetAllBulkChecksControllerTests.cs
@@ -18,6 +18,7 @@ namespace CheckYourEligibility.API.Tests.Controllers
         private Mock<IGetAllBulkChecksUseCase> _mockUseCase = null!;
         private BulkCheckController _controller = null!;
         private Mock<ILogger<BulkCheckController>> _mockLogger = null!;
+        private readonly Mock<IGetBulkCheckSummaryUseCase> _mockBulkCheckSummaryUseCase = new();
 
         [SetUp]
         public void Setup()
@@ -36,12 +37,13 @@ namespace CheckYourEligibility.API.Tests.Controllers
             var mockAudit = new Mock<IAudit>();
 
             _controller = new BulkCheckController(
-                    _mockLogger.Object,
+                _mockLogger.Object,
                 mockAudit.Object,
                 configuration,
-                    null!, null!, null!, null!, null!,
-                    _mockUseCase.Object
-                );
+                null!, null!, null!, null!, null!,
+                _mockUseCase.Object,
+                _mockBulkCheckSummaryUseCase.Object
+            );
         }
 
         [Test]

--- a/CheckYourEligibility.API.Tests/Controllers/GetAllBulkChecksControllerTests.cs
+++ b/CheckYourEligibility.API.Tests/Controllers/GetAllBulkChecksControllerTests.cs
@@ -1,6 +1,7 @@
 using CheckYourEligibility.API.Boundary.Requests;
 using CheckYourEligibility.API.Boundary.Responses;
 using CheckYourEligibility.API.Controllers;
+using CheckYourEligibility.API.Domain.Exceptions;
 using CheckYourEligibility.API.Gateways.Interfaces;
 using CheckYourEligibility.API.UseCases;
 using Microsoft.AspNetCore.Http;
@@ -182,6 +183,42 @@ namespace CheckYourEligibility.API.Tests.Controllers
             _mockUseCase.Verify(x => x.Execute(
                 It.Is<IList<int>>(ids => ids.Contains(123) && !ids.Contains(0)),
                 It.IsAny<CheckMetaData>()), Times.Once);
+        }
+
+        [Test]
+        public async Task GetBulkCheckSummary_WhenGuidDoesNotExist_ReturnsNotFound()
+        {
+            // Arrange
+            var bulkCheckId = Guid.NewGuid();
+
+            _mockBulkCheckSummaryUseCase
+                .Setup(x => x.Execute(
+                    bulkCheckId,
+                    It.IsAny<IList<int>>(),
+                    It.IsAny<CheckMetaData>()))
+                .ThrowsAsync(new NotFoundException());
+
+            var claims = new List<Claim>
+            {
+                new Claim("scope", "local_authority:123"),
+                new Claim(
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+                    "free-school-meals-admin:test-user@test.com")
+            };
+
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(claims))
+                }
+            };
+
+            // Act
+            var result = await _controller.GetBulkCheckSummary(bulkCheckId);
+
+            // Assert
+            Assert.That(result, Is.InstanceOf<NotFoundObjectResult>());
         }
     }
 }

--- a/CheckYourEligibility.API/Boundary/Responses/BulkCheckSummaryResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/BulkCheckSummaryResponse.cs
@@ -1,0 +1,15 @@
+﻿namespace CheckYourEligibility.API.Boundary.Responses
+{
+    public class BulkCheckSummaryResponse
+    {
+        public string? Filename { get; set; }
+
+        public string? Status { get; set; }
+
+        public DateTime SubmittedDate { get; set; }
+
+        public string? SubmittedBy { get; set; }
+
+        public Dictionary<string, int> Outcomes { get; set; } = new();
+    }
+}

--- a/CheckYourEligibility.API/Controllers/BulkCheckController.cs
+++ b/CheckYourEligibility.API/Controllers/BulkCheckController.cs
@@ -30,6 +30,7 @@ public class BulkCheckController : BaseController
     private readonly IGetAllBulkChecksUseCase _getAllBulkChecksUseCase;
     private readonly ILogger<BulkCheckController> _logger;
     private readonly string _localAuthorityScopeName;
+    private readonly IGetBulkCheckSummaryUseCase _getBulkCheckSummaryUseCase;
 
     public BulkCheckController(
         ILogger<BulkCheckController> logger,
@@ -40,7 +41,8 @@ public class BulkCheckController : BaseController
         IGetBulkUploadProgressUseCase getBulkUploadProgressUseCase,
         IGetBulkUploadResultsUseCase getBulkUploadResultsUseCase,
         IDeleteBulkCheckUseCase deleteBulkUploadUseCase,
-        IGetAllBulkChecksUseCase getAllBulkChecksUseCase
+        IGetAllBulkChecksUseCase getAllBulkChecksUseCase,
+        IGetBulkCheckSummaryUseCase getBulkCheckSummaryUseCase
     )
         : base(audit)
     {
@@ -54,6 +56,7 @@ public class BulkCheckController : BaseController
         _getBulkUploadResultsUseCase = getBulkUploadResultsUseCase;
         _deleteBulkUploadUseCase = deleteBulkUploadUseCase;
         _getAllBulkChecksUseCase = getAllBulkChecksUseCase;
+        _getBulkCheckSummaryUseCase = getBulkCheckSummaryUseCase;
     }
 
 

--- a/CheckYourEligibility.API/Controllers/BulkCheckController.cs
+++ b/CheckYourEligibility.API/Controllers/BulkCheckController.cs
@@ -467,14 +467,48 @@ public class BulkCheckController : BaseController
     /// <returns>
     /// A summary containing bulk check metadata and aggregated outcome counts.
     /// </returns>
-    [HttpGet("{bulkCheckId:guid}/summary")]
+    [HttpGet("/bulk-checks/{bulkCheckId:guid}/summary")]
     [Authorize(Policy = PolicyNames.RequireBulkCheckScope)]
     [Authorize(Policy = PolicyNames.RequireLaOrMatOrSchoolScope)]
     [Authorize(Policy = PolicyNames.RequireFreeSchoolMealsAdminPortalSource)]
-    public async Task<IActionResult> GetBulkCheckSummary(Guid bulkCheckId)
+    public async Task<ActionResult> GetBulkCheckSummary(Guid bulkCheckId)
     {
-        // use case call will go here next
-        throw new NotImplementedException();
+        try
+        {
+            var meta = User.CalculateMetaData();
+
+            var localAuthorityIds = User.GetSpecificScopeIds(_localAuthorityScopeName);
+            if (localAuthorityIds == null || localAuthorityIds.Count == 0)
+            {
+                return Unauthorized(new ErrorResponse
+                {
+                    Errors = [new Error { Title = "Not authorised for local authority in scope" }]
+                });
+            }
+
+            var result = await _getBulkCheckSummaryUseCase.Execute(bulkCheckId, localAuthorityIds, meta);
+
+            return new ObjectResult(result) { StatusCode = StatusCodes.Status200OK };
+        }
+        catch (NotFoundException)
+        {
+            return NotFound(new ErrorResponse { Errors = [new Error { Title = "Not Found" }] });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return Unauthorized(new ErrorResponse
+            {
+                Errors = [new Error { Title = ex.Message }]
+            });
+        }
+        catch (FluentValidation.ValidationException ex)
+        {
+            return BadRequest(new ErrorResponse { Errors = [new Error { Title = ex.Message }] });
+        }
+        catch (ValidationException ex)
+        {
+            return BadRequest(new ErrorResponse { Errors = ex.Errors });
+        }
     }
 
     /// <summary>

--- a/CheckYourEligibility.API/Controllers/BulkCheckController.cs
+++ b/CheckYourEligibility.API/Controllers/BulkCheckController.cs
@@ -460,6 +460,24 @@ public class BulkCheckController : BaseController
     }
 
     /// <summary>
+    /// Gets a summary of the specified bulk check, including outcome totals grouped by
+    /// outcome and eligibility tier.
+    /// </summary>
+    /// <param name="bulkCheckId">The unique identifier of the bulk check.</param>
+    /// <returns>
+    /// A summary containing bulk check metadata and aggregated outcome counts.
+    /// </returns>
+    [HttpGet("{bulkCheckId:guid}/summary")]
+    [Authorize(Policy = PolicyNames.RequireBulkCheckScope)]
+    [Authorize(Policy = PolicyNames.RequireLaOrMatOrSchoolScope)]
+    [Authorize(Policy = PolicyNames.RequireFreeSchoolMealsAdminPortalSource)]
+    public async Task<IActionResult> GetBulkCheckSummary(Guid bulkCheckId)
+    {
+        // use case call will go here next
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
     ///     Soft deletes bulk check given a group Id
     /// </summary>
     /// <param name="guid"></param>

--- a/CheckYourEligibility.API/Domain/Constants/PolicyNames.cs
+++ b/CheckYourEligibility.API/Domain/Constants/PolicyNames.cs
@@ -19,4 +19,5 @@ public static class PolicyNames
     public const string RequireLaOrMatScope = "RequireLaOrMatScope";
     public const string RequireLaOrMatOrSchoolScope = "RequireLaOrMatOrSchoolScope";
     public const string RequireLaOrAdminScope = "RequireLaOrAdminScope";
+    public const string RequireFreeSchoolMealsAdminPortalSource = "RequireFreeSchoolMealsAdminPortalSource";
 }

--- a/CheckYourEligibility.API/Extensions/ClaimsPrincipalExtensions.cs
+++ b/CheckYourEligibility.API/Extensions/ClaimsPrincipalExtensions.cs
@@ -19,7 +19,7 @@ public static class ClaimsPrincipalExtensions
     /// </summary>
     /// <param name="user"></param>
     /// <returns>source of check and username</returns>
-    private static (string?, string) GetCheckSourceAndUserNameFromClientId(this ClaimsPrincipal user)
+    internal static (string?, string) GetCheckSourceAndUserNameFromClientId(this ClaimsPrincipal user)
     {
 
         string userName = user.Claims.FirstOrDefault(x => x.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier").Value;

--- a/CheckYourEligibility.API/Program.cs
+++ b/CheckYourEligibility.API/Program.cs
@@ -180,6 +180,7 @@ builder.Services.AddScoped<ICheckEligibilityBulkUseCase, CheckEligibilityBulkUse
 
 builder.Services.AddScoped<IGetBulkCheckStatusesUseCase, GetBulkCheckStatusesUseCase>();
 builder.Services.AddScoped<IGetAllBulkChecksUseCase, GetAllBulkChecksUseCase>();
+builder.Services.AddScoped<IGetBulkCheckSummaryUseCase, GetBulkCheckSummaryUseCase>();
 builder.Services.AddScoped<IGetEligibilityCheckReportingUseCase, GetEligibilityCheckReportingUseCase>();
 builder.Services.AddScoped<IGetEligibilityReportStatusUseCase, GetEligibilityReportStatusUseCase>();
 builder.Services.AddScoped<IGetEligibilityCheckReportItemsUseCase, GetEligibilityCheckReportItemsUseCase>();

--- a/CheckYourEligibility.API/ProgramExtensions.cs
+++ b/CheckYourEligibility.API/ProgramExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Azure;
 using Microsoft.IdentityModel.Tokens;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Security;
+using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 namespace CheckYourEligibility.API;
@@ -244,6 +245,18 @@ public static class ProgramExtensions
                 policy.RequireAssertion(context =>
                     context.User.HasScopeWithColon(configuration["Jwt:Scopes:multi_academy_trust"] ?? "multi_academy_trust") ||
                     context.User.HasScope(configuration["Jwt:Scopes:admin"] ?? "admin")));
+            const string freeSchoolMealsAdminPortal = "free-school-meals-admin";
+
+            options.AddPolicy(PolicyNames.RequireFreeSchoolMealsAdminPortalSource, policy =>
+                policy.RequireAssertion(context =>
+                {
+                    var checkSourceAndUserName = context.User.GetCheckSourceAndUserNameFromClientId();
+
+                    return string.Equals(
+                        checkSourceAndUserName.Item1,
+                        "free-school-meals-admin",
+                        StringComparison.OrdinalIgnoreCase);
+                }));
         });
         return services;
     }

--- a/CheckYourEligibility.API/ProgramExtensions.cs
+++ b/CheckYourEligibility.API/ProgramExtensions.cs
@@ -244,8 +244,7 @@ public static class ProgramExtensions
             options.AddPolicy(PolicyNames.RequireMatOrAdminScope, policy =>
                 policy.RequireAssertion(context =>
                     context.User.HasScopeWithColon(configuration["Jwt:Scopes:multi_academy_trust"] ?? "multi_academy_trust") ||
-                    context.User.HasScope(configuration["Jwt:Scopes:admin"] ?? "admin")));
-            const string freeSchoolMealsAdminPortal = "free-school-meals-admin";
+                    context.User.HasScope(configuration["Jwt:Scopes:admin"] ?? "admin")));            
 
             options.AddPolicy(PolicyNames.RequireFreeSchoolMealsAdminPortalSource, policy =>
                 policy.RequireAssertion(context =>

--- a/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
@@ -2,6 +2,7 @@
 using CheckYourEligibility.API.Boundary.Responses;
 using CheckYourEligibility.API.Domain.Exceptions;
 using CheckYourEligibility.API.Gateways.Interfaces;
+using Polly;
 
 namespace CheckYourEligibility.API.UseCases;
 
@@ -27,23 +28,34 @@ public class GetBulkCheckSummaryUseCase : IGetBulkCheckSummaryUseCase
     }
 
     public async Task<BulkCheckSummaryResponse> Execute(
-        Guid bulkCheckId,
-        IList<int> allowedLocalAuthorityIds,
-        CheckMetaData meta)
+    Guid bulkCheckId,
+    IList<int> allowedLocalAuthorityIds,
+    CheckMetaData meta)
     {
         var bulkCheck = await _bulkCheckGateway.GetBulkCheck(bulkCheckId.ToString());
 
         if (bulkCheck == null)
         {
-            var results = await _bulkCheckGateway
-                .GetBulkCheckResults<List<CheckEligibilityItem>>(bulkCheckId.ToString());
+            throw new NotFoundException();
+        }
 
-            var outcomes = results
+        var results = await _bulkCheckGateway
+            .GetBulkCheckResults<List<CheckEligibilityItem>>(bulkCheckId.ToString());
+
+        var outcomes = results
             .GroupBy(result =>
                 string.IsNullOrWhiteSpace(result.Tier)
                     ? result.Status
                     : $"{result.Status}-{result.Tier}".ToLower())
             .ToDictionary(group => group.Key, group => group.Count());
-        }
+
+        return new BulkCheckSummaryResponse
+        {
+            Filename = bulkCheck.Filename,
+            Status = bulkCheck.Status.ToString(),
+            SubmittedDate = bulkCheck.SubmittedDate,
+            SubmittedBy = bulkCheck.SubmittedBy,
+            Outcomes = outcomes
+        };
     }
 }

--- a/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
@@ -39,6 +39,17 @@ public class GetBulkCheckSummaryUseCase : IGetBulkCheckSummaryUseCase
             throw new NotFoundException();
         }
 
+        if (!allowedLocalAuthorityIds.Contains(0) &&
+            (bulkCheck.LocalAuthorityID == null ||
+             !allowedLocalAuthorityIds.Contains(bulkCheck.LocalAuthorityID.Value)))
+        {
+            _logger.LogWarning(
+                $"User attempted to access bulk check {bulkCheckId} belonging to local authority {bulkCheck.LocalAuthorityID} without permission");
+
+            throw new UnauthorizedAccessException(
+                $"You do not have permission to access bulk check {bulkCheckId}");
+        }
+
         var results = await _bulkCheckGateway
             .GetBulkCheckResults<List<CheckEligibilityItem>>(bulkCheckId.ToString());
 

--- a/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
@@ -35,7 +35,8 @@ public class GetBulkCheckSummaryUseCase : IGetBulkCheckSummaryUseCase
 
         if (bulkCheck == null)
         {
-            throw new NotFoundException();
+            var results = await _bulkCheckGateway
+                .GetBulkCheckResults<List<CheckEligibilityItem>>(bulkCheckId.ToString());
         }
     }
 }

--- a/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
@@ -1,5 +1,6 @@
-﻿using CheckYourEligibility.API.Boundary.Responses;
-using CheckYourEligibility.API.Boundary.Requests;
+﻿using CheckYourEligibility.API.Boundary.Requests;
+using CheckYourEligibility.API.Boundary.Responses;
+using CheckYourEligibility.API.Domain.Exceptions;
 using CheckYourEligibility.API.Gateways.Interfaces;
 
 namespace CheckYourEligibility.API.UseCases;
@@ -30,6 +31,11 @@ public class GetBulkCheckSummaryUseCase : IGetBulkCheckSummaryUseCase
         IList<int> allowedLocalAuthorityIds,
         CheckMetaData meta)
     {
-        throw new NotImplementedException();
+        var bulkCheck = await _bulkCheckGateway.GetBulkCheck(bulkCheckId.ToString());
+
+        if (bulkCheck == null)
+        {
+            throw new NotFoundException();
+        }
     }
 }

--- a/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
@@ -37,6 +37,13 @@ public class GetBulkCheckSummaryUseCase : IGetBulkCheckSummaryUseCase
         {
             var results = await _bulkCheckGateway
                 .GetBulkCheckResults<List<CheckEligibilityItem>>(bulkCheckId.ToString());
+
+            var outcomes = results
+            .GroupBy(result =>
+                string.IsNullOrWhiteSpace(result.Tier)
+                    ? result.Status
+                    : $"{result.Status}-{result.Tier}".ToLower())
+            .ToDictionary(group => group.Key, group => group.Count());
         }
     }
 }

--- a/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
@@ -51,7 +51,7 @@ public class GetBulkCheckSummaryUseCase : IGetBulkCheckSummaryUseCase
         }
 
         var results = await _bulkCheckGateway
-            .GetBulkCheckResults<List<CheckEligibilityItem>>(bulkCheckId.ToString());
+            .GetBulkCheckResults<IList<CheckEligibilityItem>>(bulkCheckId.ToString());
 
         var outcomes = results
             .GroupBy(result =>

--- a/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetBulkCheckSummaryUseCase.cs
@@ -1,0 +1,35 @@
+﻿using CheckYourEligibility.API.Boundary.Responses;
+using CheckYourEligibility.API.Boundary.Requests;
+using CheckYourEligibility.API.Gateways.Interfaces;
+
+namespace CheckYourEligibility.API.UseCases;
+
+public interface IGetBulkCheckSummaryUseCase
+{
+    Task<BulkCheckSummaryResponse> Execute(
+        Guid bulkCheckId,
+        IList<int> allowedLocalAuthorityIds,
+        CheckMetaData meta);
+}
+
+public class GetBulkCheckSummaryUseCase : IGetBulkCheckSummaryUseCase
+{
+    private readonly IBulkCheck _bulkCheckGateway;
+    private readonly ILogger<GetBulkCheckSummaryUseCase> _logger;
+
+    public GetBulkCheckSummaryUseCase(
+        IBulkCheck bulkCheckGateway,
+        ILogger<GetBulkCheckSummaryUseCase> logger)
+    {
+        _bulkCheckGateway = bulkCheckGateway;
+        _logger = logger;
+    }
+
+    public async Task<BulkCheckSummaryResponse> Execute(
+        Guid bulkCheckId,
+        IList<int> allowedLocalAuthorityIds,
+        CheckMetaData meta)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
No Cypress tests added following Lead guidance. Coverage added/kept at unit/API level for the summary endpoint response and not-found path.