### PR TITLE
Elig 3335 do not include checks made by vendors in la reports

### DIFF
--- a/CheckYourEligibility.API.Tests/Controllers/EligibilityCheckReportingControllerTests.cs
+++ b/CheckYourEligibility.API.Tests/Controllers/EligibilityCheckReportingControllerTests.cs
@@ -1,3 +1,4 @@
+using CheckYourEligibility.API.Boundary.Requests;
 using CheckYourEligibility.API.Boundary.Responses;
 using CheckYourEligibility.API.Controllers;
 using CheckYourEligibility.API.Domain.Exceptions;
@@ -167,7 +168,7 @@ public class EligibilityCheckReportingControllerTests : TestBase.TestBase
 
         SetupControllerWithLocalAuthorityIds(new List<int> { 201 });
 
-        _mockEligibilityCheckReportingUseCase.Setup(u => u.Execute(It.Is<EligibilityCheckReportRequest>(r => r.LocalAuthorityID == localAuthorityId))).ReturnsAsync(reportResponse);
+        _mockEligibilityCheckReportingUseCase.Setup(u => u.Execute(It.Is<EligibilityCheckReportRequest>(r => r.LocalAuthorityID == localAuthorityId),It.IsAny<CheckMetaData>())).ReturnsAsync(reportResponse);
 
         // Act
         var response = await _sut.EligibilityCheckReportRequest(reportRequest);
@@ -210,7 +211,7 @@ public class EligibilityCheckReportingControllerTests : TestBase.TestBase
         SetupControllerWithLocalAuthorityIds(new List<int> { 201 });
 
         _mockEligibilityCheckReportingUseCase
-            .Setup(u => u.Execute(It.IsAny<EligibilityCheckReportRequest>()))
+            .Setup(u => u.Execute(It.IsAny<EligibilityCheckReportRequest>(), It.IsAny<CheckMetaData>()))
             .ThrowsAsync(new FluentValidation.ValidationException("Validation failed"));
 
         // Act

--- a/CheckYourEligibility.API.Tests/Gateways/EligibilityCheckReportingGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/EligibilityCheckReportingGatewayTests.cs
@@ -89,8 +89,8 @@ public class EligibilityCheckReportingGatewayTests : TestBase.TestBase
         updatedReport.NumberOfResults.Should().Be(totalChecks);
     }
 
-    [Test]
-    public async Task EligibilityCheckReports_Should_Classify_Bulk_And_Single_Checks()
+    [TestCase("free-school-meals-admin")]
+    public async Task EligibilityCheckReports_Should_Classify_Bulk_And_Single_Checks(string source)
     {
         // Arrange
         var now = DateTime.UtcNow;
@@ -115,13 +115,16 @@ public class EligibilityCheckReportingGatewayTests : TestBase.TestBase
                 EligibilityCheckID = "BULK",
                 OrganisationID = 948,
                 Created = now,
-                BulkCheck = bulkCheck
+                BulkCheck = bulkCheck,
+                Source = source,
             },
             new EligibilityCheck
             {
                 EligibilityCheckID = "SINGLE",
                 OrganisationID = 948,
-                Created = now
+                Created = now,
+                Source = source,
+                
             });
 
         await _fakeInMemoryDb.SaveChangesAsync();

--- a/CheckYourEligibility.API.Tests/Gateways/EligibilityCheckReportingGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/EligibilityCheckReportingGatewayTests.cs
@@ -82,7 +82,7 @@ public class EligibilityCheckReportingGatewayTests : TestBase.TestBase
         await _fakeInMemoryDb.SaveChangesAsync();
 
         // Act
-        await _sut.EligibilityCheckReports(report.EligibilityCheckReportId, CheckEligibilityType.FreeSchoolMeals, CancellationToken.None);
+        await _sut.EligibilityCheckReports(report.EligibilityCheckReportId, CheckEligibilityType.FreeSchoolMeals,null, CancellationToken.None);
 
         // Assert
         var updatedReport = await _fakeInMemoryDb.EligibilityCheckReports.SingleAsync();
@@ -130,7 +130,7 @@ public class EligibilityCheckReportingGatewayTests : TestBase.TestBase
         await _fakeInMemoryDb.SaveChangesAsync();
 
         // Act
-        var query = _sut.GetCheckQuery(report);
+        var query = _sut.GetCheckQuery(report, source);
 
         var results = await query
             .Select(e => new
@@ -182,7 +182,7 @@ public class EligibilityCheckReportingGatewayTests : TestBase.TestBase
         // Act
         await _sut.EligibilityCheckReports(
             report.EligibilityCheckReportId,
-            CheckEligibilityType.FreeSchoolMeals,
+            CheckEligibilityType.FreeSchoolMeals, null,
             CancellationToken.None);
 
         // Assert
@@ -197,7 +197,7 @@ public class EligibilityCheckReportingGatewayTests : TestBase.TestBase
     public async Task EligibilityCheckReports_ReportNotFound_Throws()
     {
         Func<Task> act = async () =>
-            await _sut.EligibilityCheckReports(Guid.NewGuid(), CheckEligibilityType.FreeSchoolMeals, CancellationToken.None);
+            await _sut.EligibilityCheckReports(Guid.NewGuid(), CheckEligibilityType.FreeSchoolMeals,null, CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
@@ -209,7 +209,7 @@ public class EligibilityCheckReportingGatewayTests : TestBase.TestBase
         var emptyReportId = Guid.Empty;
 
         // Act
-        Func<Task> act = async () => await _sut.EligibilityCheckReports(emptyReportId, CheckEligibilityType.FreeSchoolMeals, CancellationToken.None);
+        Func<Task> act = async () => await _sut.EligibilityCheckReports(emptyReportId, CheckEligibilityType.FreeSchoolMeals,null, CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<ArgumentNullException>();

--- a/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckReportingUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckReportingUseCaseTests.cs
@@ -1,3 +1,4 @@
+using CheckYourEligibility.API.Boundary.Requests;
 using CheckYourEligibility.API.Domain.Enums;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -113,6 +114,15 @@ public class GetEligibilityCheckReportingUseCaseTests : TestBase.TestBase
             EndDate = DateTime.UtcNow.AddDays(-1)
         };
 
+        var metaData = new CheckMetaData {
+
+            OrganisationID = 894,
+            OrganisationType = "local-authority",
+            Source = "free-school-meals-admin",
+            UserName = "test@edication.gov.uk"
+            
+        };
+
         var reportId = Guid.NewGuid();
 
         _mockEligibilityCheckReportingGateway
@@ -128,7 +138,7 @@ public class GetEligibilityCheckReportingUseCaseTests : TestBase.TestBase
         .Returns(Task.CompletedTask);
 
         // Act
-        await _sut.Execute(model, null);
+        await _sut.Execute(model, metaData);
 
         // Give the background Task.Run time to execute
         await Task.Delay(50);

--- a/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckReportingUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckReportingUseCaseTests.cs
@@ -38,7 +38,7 @@ public class GetEligibilityCheckReportingUseCaseTests : TestBase.TestBase
     public void Execute_WhenModelIsNull_ThrowsValidationException()
     {
         var ex = Assert.ThrowsAsync<System.ComponentModel.DataAnnotations.ValidationException>(
-            async () => await _sut.Execute(null));
+            async () => await _sut.Execute(null,null));
 
         Assert.That(ex.Message, Is.EqualTo("Invalid request, model is required"));
     }
@@ -51,7 +51,7 @@ public class GetEligibilityCheckReportingUseCaseTests : TestBase.TestBase
 
         // Act
         var ex = Assert.ThrowsAsync<FluentValidation.ValidationException>(
-            async () => await _sut.Execute(invalidModel));
+            async () => await _sut.Execute(invalidModel, null));
 
         // Assert
         Assert.That(ex, Is.Not.Null);
@@ -85,12 +85,12 @@ public class GetEligibilityCheckReportingUseCaseTests : TestBase.TestBase
             .ReturnsAsync(createdReport);
 
         _mockEligibilityCheckReportingGateway
-            .Setup(g => g.EligibilityCheckReports(reportId, CheckEligibilityType.FreeSchoolMeals, It.IsAny<CancellationToken>()))
+            .Setup(g => g.EligibilityCheckReports(reportId, CheckEligibilityType.FreeSchoolMeals,It.IsAny<string>() ,It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
 
         // Act
-        var result = await _sut.Execute(model);
+        var result = await _sut.Execute(model, null);
 
         // Assert
         Assert.That(result, Is.Not.Null);
@@ -124,18 +124,18 @@ public class GetEligibilityCheckReportingUseCaseTests : TestBase.TestBase
             });
 
         _mockEligibilityCheckReportingGateway
-        .Setup(g => g.EligibilityCheckReports(reportId, CheckEligibilityType.FreeSchoolMeals, It.IsAny<CancellationToken>()))
+        .Setup(g => g.EligibilityCheckReports(reportId, CheckEligibilityType.FreeSchoolMeals,It.IsAny<string>(), It.IsAny<CancellationToken>()))
         .Returns(Task.CompletedTask);
 
         // Act
-        await _sut.Execute(model);
+        await _sut.Execute(model, null);
 
         // Give the background Task.Run time to execute
         await Task.Delay(50);
 
         // Assert
         _mockEligibilityCheckReportingGateway.Verify(
-            g => g.EligibilityCheckReports(reportId, CheckEligibilityType.FreeSchoolMeals, It.IsAny<CancellationToken>()),
+            g => g.EligibilityCheckReports(reportId, CheckEligibilityType.FreeSchoolMeals, It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/CheckYourEligibility.API/Controllers/EligibilityCheckReportingController.cs
+++ b/CheckYourEligibility.API/Controllers/EligibilityCheckReportingController.cs
@@ -137,7 +137,8 @@ public class EligibilityCheckReportingController : BaseController
                 });
             }
 
-            var result = await _getEligibilityCheckReportingUseCase.Execute(model);
+            var meta = User.CalculateMetaData();
+            var result = await _getEligibilityCheckReportingUseCase.Execute(model,meta);
 
             return new ObjectResult(result) { StatusCode = StatusCodes.Status202Accepted };
         }

--- a/CheckYourEligibility.API/Gateways/EligibilityCheckReportingGateway.cs
+++ b/CheckYourEligibility.API/Gateways/EligibilityCheckReportingGateway.cs
@@ -63,7 +63,7 @@ public sealed class EligibilityCheckReportingGateway : IEligibilityCheckReportin
     /// <exception cref="InvalidOperationException"></exception>
     public async Task EligibilityCheckReports(
     Guid reportId,
-    CheckEligibilityType eligiblityCheckType,
+    CheckEligibilityType eligiblityCheckType,string? source,
     CancellationToken cancellationToken = default)
     {
         if (reportId == Guid.Empty)
@@ -90,7 +90,7 @@ public sealed class EligibilityCheckReportingGateway : IEligibilityCheckReportin
         {
             while (true)
             {
-                var query = GetCheckQuery(report);
+                var query = GetCheckQuery(report, source);
 
                 // only apply filter after first batch
                 if (lastProcessedCheckId != null)
@@ -267,7 +267,7 @@ public sealed class EligibilityCheckReportingGateway : IEligibilityCheckReportin
     );
 
     // public to allow testing
-    public IQueryable<EligibilityCheck> GetCheckQuery(EligibilityCheckReport request)
+    public IQueryable<EligibilityCheck> GetCheckQuery(EligibilityCheckReport request, string source )
     {
         return request.CheckType switch
         {
@@ -277,24 +277,26 @@ public sealed class EligibilityCheckReportingGateway : IEligibilityCheckReportin
                         b.LocalAuthorityID == request.LocalAuthorityID &&
                         b.SubmittedDate >= request.StartDate &&
                         b.SubmittedDate <= request.EndDate)
-                    .SelectMany(b => b.EligibilityChecks!)
+                    .SelectMany(b => b.EligibilityChecks!).Where(c => c.Source == source)
                     .AsNoTracking(),
 
             CheckType.IndividualChecks =>
                 _db.CheckEligibilities
                     .Where(c =>
-                        c.BulkCheck == null &&
-                        c.OrganisationID == request.LocalAuthorityID &&
-                        c.Created >= request.StartDate &&
-                        c.Created <= request.EndDate)
+                       c.Source == source &&
+                       c.Created >= request.StartDate &&
+                       c.Created <= request.EndDate &&
+                       c.BulkCheckID == null &&
+                       c.OrganisationID == request.LocalAuthorityID)
                     .AsNoTracking(),
 
             CheckType.AllChecks =>
                 _db.CheckEligibilities
                     .Where(c =>
-                        c.OrganisationID == request.LocalAuthorityID &&
-                        c.Created >= request.StartDate &&
-                        c.Created <= request.EndDate)
+                       c.Source  == source &&
+                       c.Created >= request.StartDate &&
+                       c.Created <= request.EndDate &&
+                       c.OrganisationID == request.LocalAuthorityID)
                     .AsNoTracking(),
 
             _ => throw new ArgumentOutOfRangeException(nameof(request.CheckType))

--- a/CheckYourEligibility.API/Gateways/Interfaces/IEligibilityCheckReporting.cs
+++ b/CheckYourEligibility.API/Gateways/Interfaces/IEligibilityCheckReporting.cs
@@ -3,7 +3,7 @@ using CheckYourEligibility.API.Domain.Enums;
 
 public interface IEligibilityCheckReporting
 {
-    Task EligibilityCheckReports(Guid reportId, CheckEligibilityType eligiblityCheckType, CancellationToken cancellationToken = default);
+    Task EligibilityCheckReports(Guid reportId, CheckEligibilityType eligiblityCheckType,string? source, CancellationToken cancellationToken = default);
     Task<EligibilityCheckReport> CreateReport(EligibilityCheckReportRequest request, CancellationToken cancellationToken = default);
     Task<EligibilityCheckReportHistoryResponse> GetEligibilityCheckReportHistory(string localAuthorityId, int pageNumber);
     Task<int> GetLocalAuthorityIdForReport(Guid reportId, CancellationToken cancellationToken = default);

--- a/CheckYourEligibility.API/Usecases/GetEligibilityCheckReportingUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetEligibilityCheckReportingUseCase.cs
@@ -44,7 +44,7 @@ public class GetEligibilityCheckReportingUseCase : IGetEligibilityCheckReporting
             var gateway = scope.ServiceProvider.GetRequiredService<IEligibilityCheckReporting>();
             try
             {
-                await gateway.EligibilityCheckReports(reportRequest.EligibilityCheckReportId, model.EligibilityCheckType,null, CancellationToken.None);
+                await gateway.EligibilityCheckReports(reportRequest.EligibilityCheckReportId, model.EligibilityCheckType,meta.Source, CancellationToken.None);
             }
             catch (Exception ex)
             {
@@ -61,7 +61,6 @@ public class GetEligibilityCheckReportingUseCase : IGetEligibilityCheckReporting
                 Status = reportRequest.Status.ToString()
             }
         };
-
         
     }
 }

--- a/CheckYourEligibility.API/Usecases/GetEligibilityCheckReportingUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetEligibilityCheckReportingUseCase.cs
@@ -1,3 +1,4 @@
+using CheckYourEligibility.API.Boundary.Requests;
 using System.ComponentModel.DataAnnotations;
 
 public interface IGetEligibilityCheckReportingUseCase
@@ -7,7 +8,7 @@ public interface IGetEligibilityCheckReportingUseCase
     /// </summary>
     /// <param name="model">The request model containing parameters for report generation</param>
     /// <returns>A stream containing the generated report</returns>
-    Task<EligibilityCheckReportResponse> Execute(EligibilityCheckReportRequest model);
+    Task<EligibilityCheckReportResponse> Execute(EligibilityCheckReportRequest model, CheckMetaData meta);
 }
 
 public class GetEligibilityCheckReportingUseCase : IGetEligibilityCheckReportingUseCase
@@ -23,7 +24,7 @@ public class GetEligibilityCheckReportingUseCase : IGetEligibilityCheckReporting
         _scopeFactory = scopeFactory;
     }
 
-    public async Task<EligibilityCheckReportResponse> Execute(EligibilityCheckReportRequest model)
+    public async Task<EligibilityCheckReportResponse> Execute(EligibilityCheckReportRequest model, CheckMetaData meta)
     {
         if (model == null) throw new ValidationException("Invalid request, model is required");
 
@@ -43,7 +44,7 @@ public class GetEligibilityCheckReportingUseCase : IGetEligibilityCheckReporting
             var gateway = scope.ServiceProvider.GetRequiredService<IEligibilityCheckReporting>();
             try
             {
-                await gateway.EligibilityCheckReports(reportRequest.EligibilityCheckReportId, model.EligibilityCheckType, CancellationToken.None);
+                await gateway.EligibilityCheckReports(reportRequest.EligibilityCheckReportId, model.EligibilityCheckType,null, CancellationToken.None);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
- ensure report items are filtered by source when being generated. This change will only include check created through the portal.