### PR TITLE
Elig 3344 add completed date to bulk checks and emit a log event at completion for metrics

### DIFF
--- a/CheckYourEligibility.API.Tests/Usecases/ProcessEligibilityCheckQueueBulkCheckUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/ProcessEligibilityCheckQueueBulkCheckUseCaseTests.cs
@@ -165,6 +165,7 @@ public class ProcessEligibilityBulkCheckUseCaseBulkTests : TestBase.TestBase
         var bulk = db.BulkChecks.First(x => x.BulkCheckID == bulkId);
 
         bulk.Status.Should().Be(BulkCheckStatus.Completed);
+        bulk.CompletedDate.Should().NotBeNull();
     }
 
     #region Helpers

--- a/CheckYourEligibility.API.Tests/Usecases/ProcessEligibilityCheckQueueBulkCheckUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/ProcessEligibilityCheckQueueBulkCheckUseCaseTests.cs
@@ -100,6 +100,7 @@ public class ProcessEligibilityBulkCheckUseCaseBulkTests : TestBase.TestBase
         var bulk = db.BulkChecks.First(x => x.BulkCheckID == bulkId);
 
         bulk.Status.Should().Be(BulkCheckStatus.InProgress);
+        bulk.CompletedDate.Should().BeNull();
     }
 
     [Test]
@@ -132,6 +133,7 @@ public class ProcessEligibilityBulkCheckUseCaseBulkTests : TestBase.TestBase
         var bulk = db.BulkChecks.First(x => x.BulkCheckID == bulkId);
 
         bulk.Status.Should().Be(BulkCheckStatus.InProgress);
+        bulk.CompletedDate.Should().BeNull();
     }
 
     [Test]

--- a/CheckYourEligibility.API/Domain/BulkCheck.cs
+++ b/CheckYourEligibility.API/Domain/BulkCheck.cs
@@ -16,7 +16,9 @@ public class BulkCheck
     public CheckEligibilityType EligibilityType { get; set; }
     
     public DateTime SubmittedDate { get; set; }
-    
+
+    public DateTime? CompletedDate { get; set; }
+
     [Column(TypeName = "varchar(100)")]
     public string SubmittedBy { get; set; } = string.Empty;
     

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -76,6 +76,15 @@ public class CheckEligibilityGateway : ICheckEligibility
                     bulkCheck.CompletedDate = DateTime.UtcNow;
 
                     await _db.SaveChangesAsync();
+
+                    var elapsedTime = bulkCheck.CompletedDate.Value - bulkCheck.SubmittedDate;
+
+                    _logger.LogInformation(
+                        "BulkCheckFinished BulkCheckId={BulkCheckId} Status={Status} CompletedDate={CompletedDate} ElapsedMilliseconds={ElapsedMilliseconds}",
+                        bulkCheck.BulkCheckID,
+                        bulkCheck.Status,
+                        bulkCheck.CompletedDate,
+                        elapsedTime.TotalMilliseconds);
                 }
             }
         }
@@ -98,6 +107,15 @@ public class CheckEligibilityGateway : ICheckEligibility
                     bulkCheck.CompletedDate = DateTime.UtcNow;
 
                     await _db.SaveChangesAsync();
+
+                    var elapsedTime = bulkCheck.CompletedDate.Value - bulkCheck.SubmittedDate;
+
+                    _logger.LogInformation(
+                        "BulkCheckFinished BulkCheckId={BulkCheckId} Status={Status} CompletedDate={CompletedDate} ElapsedMilliseconds={ElapsedMilliseconds}",
+                        bulkCheck.BulkCheckID,
+                        bulkCheck.Status,
+                        bulkCheck.CompletedDate,
+                        elapsedTime.TotalMilliseconds);
                 }
             }
             catch (Exception statusUpdateEx)

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -67,9 +67,16 @@ public class CheckEligibilityGateway : ICheckEligibility
             }
             else
             {
-                var bulkCheck = _db.BulkChecks.Where(x => x.BulkCheckID == groupId).FirstOrDefault();
-                bulkCheck.Status = BulkCheckStatus.Completed;
-                await _db.SaveChangesAsync();
+                var bulkCheck = await _db.BulkChecks
+                    .FirstOrDefaultAsync(x => x.BulkCheckID == groupId);
+
+                if (bulkCheck != null)
+                {
+                    bulkCheck.Status = BulkCheckStatus.Completed;
+                    bulkCheck.CompletedDate = DateTime.UtcNow;
+
+                    await _db.SaveChangesAsync();
+                }
             }
         }
         catch (Exception e)
@@ -88,6 +95,8 @@ public class CheckEligibilityGateway : ICheckEligibility
                 if (bulkCheck != null)
                 {
                     bulkCheck.Status = BulkCheckStatus.Failed;
+                    bulkCheck.CompletedDate = DateTime.UtcNow;
+
                     await _db.SaveChangesAsync();
                 }
             }

--- a/CheckYourEligibility.API/Migrations/20260715153412_AddCompletedDateToBulkChecks.Designer.cs
+++ b/CheckYourEligibility.API/Migrations/20260715153412_AddCompletedDateToBulkChecks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CheckYourEligibility.API.Migrations
 {
     [DbContext(typeof(EligibilityCheckContext))]
-    partial class EligibilityCheckContextModelSnapshot : ModelSnapshot
+    [Migration("20260715153412_AddCompletedDateToBulkChecks")]
+    partial class AddCompletedDateToBulkChecks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CheckYourEligibility.API/Migrations/20260715153412_AddCompletedDateToBulkChecks.cs
+++ b/CheckYourEligibility.API/Migrations/20260715153412_AddCompletedDateToBulkChecks.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CheckYourEligibility.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompletedDateToBulkChecks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CompletedDate",
+                table: "BulkChecks",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CompletedDate",
+                table: "BulkChecks");
+        }
+    }
+}

--- a/CheckYourEligibility.API/Usecases/ProcessEligibilityBulkCheckUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ProcessEligibilityBulkCheckUseCase.cs
@@ -204,7 +204,10 @@ public class ProcessEligibilityBulkCheckUseCase : IProcessEligibilityBulkCheckUs
             if (bulkCheck != null)
             {
                 _logger.LogInformation($"Updating bulk check status to Completed for ID: {bulkCheckId}");
+
                 bulkCheck.Status = BulkCheckStatus.Completed;
+                bulkCheck.CompletedDate = DateTime.UtcNow;
+
                 await _db.SaveChangesAsync();
             }
         }

--- a/CheckYourEligibility.API/Usecases/ProcessEligibilityBulkCheckUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/ProcessEligibilityBulkCheckUseCase.cs
@@ -209,6 +209,15 @@ public class ProcessEligibilityBulkCheckUseCase : IProcessEligibilityBulkCheckUs
                 bulkCheck.CompletedDate = DateTime.UtcNow;
 
                 await _db.SaveChangesAsync();
+
+                var elapsedTime = bulkCheck.CompletedDate.Value - bulkCheck.SubmittedDate;
+
+                _logger.LogInformation(
+                    "BulkCheckFinished BulkCheckId={BulkCheckId} Status={Status} CompletedDate={CompletedDate} ElapsedMilliseconds={ElapsedMilliseconds}",
+                    bulkCheck.BulkCheckID,
+                    bulkCheck.Status,
+                    bulkCheck.CompletedDate,
+                    elapsedTime.TotalMilliseconds);
             }
         }
         else


### PR DESCRIPTION
## Summary

Adds support for recording when a bulk check reaches a terminal state and emits a structured log event for bulk check completion metrics.

### Changes
- Added nullable `CompletedDate` to the `BulkCheck` model.
- Added EF migration to create the `CompletedDate` column.
- Populated `CompletedDate` when a bulk check completes successfully.
- Populated `CompletedDate` when a bulk check fails.
- Added structured placeholder log events containing:
  - BulkCheckId
  - Status
  - CompletedDate
  - ElapsedMilliseconds
- Updated unit tests to verify `CompletedDate` is populated on completion and remains null while processing.

### Notes
The structured log event currently uses a placeholder event name/format. As discussed with Jim, this can be updated once James Sheppard confirms the preferred format for Splunk reporting.