### PR TITLE
Elig 3367 back end implement error code generation and return for single technical error outcomes

### DIFF
--- a/CheckYourEligibility.API.Tests/Gateways/CheckEligibilityGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/CheckEligibilityGatewayTests.cs
@@ -281,6 +281,38 @@ public class CheckEligibilityGatewayTests : TestBase.TestBase
     }
 
     [Test]
+    public async Task Given_CheckDataContainsErrorCode_GetStatus_Should_Return_ErrorCode()
+    {
+        // Arrange
+        var item = _fixture.Create<EligibilityCheck>();
+        item.Type = CheckEligibilityType.FreeSchoolMeals;
+        item.Status = CheckEligibilityStatus.eligible;
+        item.Tier = null;
+        item.IsDeleted = false;
+        item.CheckData = JsonConvert.SerializeObject(new CheckProcessData
+        {
+            ErrorCode = "STE10"
+        });
+
+        _fakeInMemoryDb.CheckEligibilities.Add(item);
+        await _fakeInMemoryDb.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetStatusAsync(
+            item.EligibilityCheckID,
+            CheckEligibilityType.FreeSchoolMeals);
+
+        var status = result.Item1;
+        var tier = result.Item2;
+        var errorCode = result.Item3;
+
+        // Assert
+        status.Should().Be(item.Status);
+        tier.Should().BeNull();
+        errorCode.Should().Be("STE10");
+    }
+
+    [Test]
     public async Task Given_ValidRequest_SameType_GetStatus_Should_Return_status()
     {
         // Arrange

--- a/CheckYourEligibility.API.Tests/Gateways/CheckEligibilityGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/CheckEligibilityGatewayTests.cs
@@ -19,7 +19,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Newtonsoft.Json;
-using System.Timers;
 
 namespace CheckYourEligibility.API.Tests;
 

--- a/CheckYourEligibility.API.Tests/Gateways/CheckEligibilityGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/CheckEligibilityGatewayTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Newtonsoft.Json;
+using System.Timers;
 
 namespace CheckYourEligibility.API.Tests;
 
@@ -166,7 +167,9 @@ public class CheckEligibilityGatewayTests : TestBase.TestBase
         var guid = _fixture.Create<Guid>().ToString();
 
         // Act
-        var (status, tier) = await _sut.GetStatusAsync(guid, CheckEligibilityType.None);
+        var (status, tier, _) = await _sut.GetStatusAsync(
+            guid,
+            CheckEligibilityType.None);
 
         // Assert
         status.Should().BeNull();
@@ -178,14 +181,21 @@ public class CheckEligibilityGatewayTests : TestBase.TestBase
     {
         // Arrange
         var item = _fixture.Create<EligibilityCheck>();
-        item.Status = CheckEligibilityStatus.eligible; // Ensure not deleted status
+        item.Status = CheckEligibilityStatus.eligible;
         item.Tier = null;
         item.IsDeleted = false;
+        item.CheckData = "{}";
+
         _fakeInMemoryDb.CheckEligibilities.Add(item);
         await _fakeInMemoryDb.SaveChangesAsync();
 
         // Act
-        var (status, tier) = await _sut.GetStatusAsync(item.EligibilityCheckID, CheckEligibilityType.None);
+        var result = await _sut.GetStatusAsync(
+            item.EligibilityCheckID,
+            CheckEligibilityType.None);
+
+        var status = result.Item1;
+        var tier = result.Item2;
 
         // Assert
         status.ToString().Should().Be(item.Status.ToString());
@@ -200,16 +210,25 @@ public class CheckEligibilityGatewayTests : TestBase.TestBase
         item.Status = CheckEligibilityStatus.eligible; // Ensure not deleted status
         item.Tier = EligibilityTier.expanded;
         item.IsDeleted = false;
+        item.CheckData = "{}";
+
         _fakeInMemoryDb.CheckEligibilities.Add(item);
         await _fakeInMemoryDb.SaveChangesAsync();
 
         // Act
-        var (status, tier) = await _sut.GetStatusAsync(item.EligibilityCheckID, CheckEligibilityType.None);
+        var result = await _sut.GetStatusAsync(
+            item.EligibilityCheckID,
+            CheckEligibilityType.None);
+
+        var status = result.Item1;
+        var tier = result.Item2;
+        var errorCode = result.Item3;
 
         // Assert
         status.ToString().Should().Be(item.Status.ToString());
         tier.ToString().Should().Be(EligibilityTier.expanded.ToString());
     }
+
     [Test]
     public async Task Given_ValidRequest_GetStatus_Should_Return_Eligible_Targeted()
     {
@@ -217,28 +236,44 @@ public class CheckEligibilityGatewayTests : TestBase.TestBase
         var item = _fixture.Create<EligibilityCheck>();
         item.Status = CheckEligibilityStatus.eligible; // Ensure not deleted status
         item.Tier = EligibilityTier.targeted;
+        item.CheckData = "{}";
+
         _fakeInMemoryDb.CheckEligibilities.Add(item);
         await _fakeInMemoryDb.SaveChangesAsync();
 
         // Act
-        var (status, tier) = await _sut.GetStatusAsync(item.EligibilityCheckID, CheckEligibilityType.None);
+        var result = await _sut.GetStatusAsync(
+            item.EligibilityCheckID,
+            CheckEligibilityType.None);
+
+        var status = result.Item1;
+        var tier = result.Item2;        
 
         // Assert
         status.ToString().Should().Be(item.Status.ToString());
         tier.ToString().Should().Be(EligibilityTier.targeted.ToString());
     }
+
     [Test]
     public async Task Given_ValidRequest_DiffType_GetStatus_Should_Return_null()
     {
         // Arrange
         var item = _fixture.Create<EligibilityCheck>();
         item.Type = CheckEligibilityType.FreeSchoolMeals;
+        item.CheckData = "{}";
+
         var type = CheckEligibilityType.EarlyYearPupilPremium;
+
         _fakeInMemoryDb.CheckEligibilities.Add(item);
         await _fakeInMemoryDb.SaveChangesAsync();
 
         // Act
-        var (status, tier) = await _sut.GetStatusAsync(item.EligibilityCheckID, type);
+        var result = await _sut.GetStatusAsync(
+            item.EligibilityCheckID,
+            type);
+
+        var status = result.Item1;
+        var tier = result.Item2;
 
         // Assert
         status.Should().BeNull();
@@ -251,13 +286,21 @@ public class CheckEligibilityGatewayTests : TestBase.TestBase
         // Arrange
         var item = _fixture.Create<EligibilityCheck>();
         item.Type = CheckEligibilityType.FreeSchoolMeals;
-        var type = CheckEligibilityType.FreeSchoolMeals;
         item.Tier = null;
+        item.CheckData = "{}";
+
+        var type = CheckEligibilityType.FreeSchoolMeals;
+
         _fakeInMemoryDb.CheckEligibilities.Add(item);
         await _fakeInMemoryDb.SaveChangesAsync();
 
         // Act
-        var (status, tier) = await _sut.GetStatusAsync(item.EligibilityCheckID, type);
+        var result = await _sut.GetStatusAsync(
+            item.EligibilityCheckID,
+            type);
+
+        var status = result.Item1;
+        var tier = result.Item2;
 
         // Assert
         status.ToString().Should().Be(item.Status.ToString());

--- a/CheckYourEligibility.API.Tests/Gateways/CheckingEngineGatewayTests.cs
+++ b/CheckYourEligibility.API.Tests/Gateways/CheckingEngineGatewayTests.cs
@@ -579,11 +579,14 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
     [TestCase(HttpStatusCode.InternalServerError, CheckEligibilityStatus.queuedForProcessing)]
     [TestCase(HttpStatusCode.UnprocessableEntity, CheckEligibilityStatus.parentNotFound)]
-    public async Task Given_validRequest_DWP_Citizen_Claim_Request_Throws_Error_Process_Should_Return_checkStatus(HttpStatusCode capiStatusCode, CheckEligibilityStatus checkStatus)
+    public async Task Given_validRequest_DWP_Citizen_Claim_Request_Throws_Error_Process_Should_Return_checkStatus(
+    HttpStatusCode capiStatusCode,
+    CheckEligibilityStatus checkStatus)
     {
         // Arrange
         var capiClaimResponse = _fixture.Create<CAPIClaimResponseBase>();
         capiClaimResponse.ResponseCode = capiStatusCode;
+        capiClaimResponse.ErrorCode = "STE20";
 
         var item = _fixture.Create<EligibilityCheck>();
         item.IsDeleted = false;
@@ -592,31 +595,56 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
         var fsm = _fixture.Create<CheckEligibilityRequestData>();
         fsm.DateOfBirth = "1990-01-01";
+
         var dataItem = GetCheckProcessData(fsm);
         item.Type = CheckEligibilityType.FreeSchoolMeals;
         item.CheckData = JsonConvert.SerializeObject(dataItem);
 
-        CAPICitizenResponse citizenResponse = _fixture.Create<CAPICitizenResponse>();
+        var citizenResponse = _fixture.Create<CAPICitizenResponse>();
         citizenResponse.ResponseCode = HttpStatusCode.OK;
+
         _fakeInMemoryDb.CheckEligibilities.Add(item);
         await _fakeInMemoryDb.SaveChangesAsync();
 
-        _moqEcsGateway.Setup(x => x.UseEcsforChecks).Returns("false");
-        
-        _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
+        _moqEcsGateway
+            .Setup(x => x.UseEcsforChecks)
+            .Returns("false");
+
+        _moqDwpGateway
+            .Setup(x => x.GetCitizen(
+                It.IsAny<CitizenMatchRequest>(),
+                It.IsAny<CheckEligibilityType>(),
+                It.IsAny<string>()))
             .ReturnsAsync(citizenResponse);
-        
-        _moqDwpGateway.Setup(x => x.GetCitizenClaims(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
-         It.IsAny<CheckEligibilityType>(), It.IsAny<string>(), It.IsAny<EligibilityPolicy>()))
-     .ReturnsAsync(capiClaimResponse);
 
-        _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
+        _moqDwpGateway
+            .Setup(x => x.GetCitizenClaims(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CheckEligibilityType>(),
+                It.IsAny<string>(),
+                It.IsAny<EligibilityPolicy>()))
+            .ReturnsAsync(capiClaimResponse);
 
+        _moqAudit
+            .Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null))
+            .ReturnsAsync("");
 
         // Act
         var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
+
         // Assert
         status.Should().Be(checkStatus);
+
+        var updatedCheck = _fakeInMemoryDb.CheckEligibilities
+            .First(x => x.EligibilityCheckID == item.EligibilityCheckID);
+
+        var checkData =
+            JsonConvert.DeserializeObject<CheckProcessData>(updatedCheck.CheckData);
+
+        checkData.Should().NotBeNull();
+        checkData!.ErrorCode.Should().Be("STE20");
     }
 
 
@@ -629,6 +657,7 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
         citizenResponse.ResponseCode = capiStatusCode;
         citizenResponse.Guid = string.Empty;
         citizenResponse.CheckEligibilityStatus = CheckEligibilityStatus.error;
+        citizenResponse.ErrorCode = "STE10";
 
         var item = _fixture.Create<EligibilityCheck>();
         item.IsDeleted = false;
@@ -657,6 +686,64 @@ public class CheckingEngineGatewayTests : TestBase.TestBase
 
         // Assert
         status.Should().Be(checkStatus);
+
+        var updatedCheck = _fakeInMemoryDb.CheckEligibilities
+            .First(x => x.EligibilityCheckID == item.EligibilityCheckID);
+
+        var checkData =
+            JsonConvert.DeserializeObject<CheckProcessData>(updatedCheck.CheckData);
+
+        checkData.Should().NotBeNull();
+        checkData!.ErrorCode.Should().Be("STE10");
+    }
+
+    [TestCase(HttpStatusCode.InternalServerError, CheckEligibilityStatus.queuedForProcessing)]
+    [TestCase(HttpStatusCode.UnprocessableEntity, CheckEligibilityStatus.parentNotFound)]
+    public async Task Given_validRequest_DWP_Citizen_Request_With_No_ErrorCode_Should_Default_To_STE50(HttpStatusCode capiStatusCode, CheckEligibilityStatus checkStatus)
+    {
+        // Arrange
+        CAPICitizenResponse citizenResponse = _fixture.Create<CAPICitizenResponse>();
+        citizenResponse.ResponseCode = capiStatusCode;
+        citizenResponse.Guid = string.Empty;
+        citizenResponse.CheckEligibilityStatus = CheckEligibilityStatus.error;
+        citizenResponse.ErrorCode = null;
+
+        var item = _fixture.Create<EligibilityCheck>();
+        item.IsDeleted = false;
+        item.Status = CheckEligibilityStatus.queuedForProcessing;
+        item.EligibilityCheckID = Guid.NewGuid().ToString();
+
+        var fsm = _fixture.Create<CheckEligibilityRequestData>();
+        fsm.DateOfBirth = "1990-01-01";
+        fsm.Type = CheckEligibilityType.FreeSchoolMeals;
+
+        var dataItem = GetCheckProcessData(fsm);
+        item.Type = fsm.Type;
+        item.CheckData = JsonConvert.SerializeObject(dataItem);
+        _fakeInMemoryDb.CheckEligibilities.Add(item);
+        await _fakeInMemoryDb.SaveChangesAsync();
+
+        _moqEcsGateway.Setup(x => x.UseEcsforChecks).Returns("false");
+
+        _moqDwpGateway.Setup(x => x.GetCitizen(It.IsAny<CitizenMatchRequest>(), It.IsAny<CheckEligibilityType>(), It.IsAny<string>()))
+            .ReturnsAsync(citizenResponse);
+
+        _moqAudit.Setup(x => x.AuditAdd(It.IsAny<AuditData>(), null)).ReturnsAsync("");
+
+        // Act
+        var (status, tier) = await _sut.ProcessCheckAsync(item.EligibilityCheckID);
+
+        // Assert
+        status.Should().Be(checkStatus);
+
+        var updatedCheck = _fakeInMemoryDb.CheckEligibilities
+            .First(x => x.EligibilityCheckID == item.EligibilityCheckID);
+
+        var checkData =
+            JsonConvert.DeserializeObject<CheckProcessData>(updatedCheck.CheckData);
+
+        checkData.Should().NotBeNull();
+        checkData!.ErrorCode.Should().Be("STE50");
     }
 
     [Test]

--- a/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckStatusUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckStatusUseCaseTests.cs
@@ -55,7 +55,12 @@ public class GetEligibilityCheckStatusUseCaseTests : TestBase.TestBase
         // Arrange
         var guid = _fixture.Create<string>();
         var type = _fixture.Create<CheckEligibilityType>();
-        _mockCheckGateway.Setup(s => s.GetStatusAsync(guid, type)).ReturnsAsync(((CheckEligibilityStatus?)null, (EligibilityTier?)null));
+        _mockCheckGateway
+            .Setup(s => s.GetStatusAsync(guid, type))
+            .ReturnsAsync((
+                (CheckEligibilityStatus?)null,
+                (EligibilityTier?)null,
+                (string?)null));
 
         // Act
         Func<Task> act = async () => await _sut.Execute(guid, type);
@@ -71,7 +76,12 @@ public class GetEligibilityCheckStatusUseCaseTests : TestBase.TestBase
         var guid = _fixture.Create<string>();
         var type = _fixture.Create<CheckEligibilityType>();
         var expectedStatusCode = CheckEligibilityStatus.queuedForProcessing;
-        _mockCheckGateway.Setup(s => s.GetStatusAsync(guid, type)).ReturnsAsync((expectedStatusCode, null));
+        _mockCheckGateway
+            .Setup(s => s.GetStatusAsync(guid, type))
+            .ReturnsAsync((
+                (CheckEligibilityStatus?)expectedStatusCode,
+                (EligibilityTier?)null,
+                (string?)null));
 
         // Act
         var result = await _sut.Execute(guid, type);
@@ -89,7 +99,12 @@ public class GetEligibilityCheckStatusUseCaseTests : TestBase.TestBase
         var guid = _fixture.Create<Guid>().ToString();
         var type = _fixture.Create<CheckEligibilityType>();
         var statusValue = _fixture.Create<CheckEligibilityStatus>();
-        _mockCheckGateway.Setup(s => s.GetStatusAsync(guid, type)).ReturnsAsync((statusValue, null));
+        _mockCheckGateway
+            .Setup(s => s.GetStatusAsync(guid, type))
+            .ReturnsAsync((
+                (CheckEligibilityStatus?)statusValue,
+                (EligibilityTier?)null,
+                (string?)null));
         // Act
         await _sut.Execute(guid, type);
 

--- a/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckStatusUseCaseTests.cs
+++ b/CheckYourEligibility.API.Tests/Usecases/GetEligibilityCheckStatusUseCaseTests.cs
@@ -93,6 +93,31 @@ public class GetEligibilityCheckStatusUseCaseTests : TestBase.TestBase
     }
 
     [Test]
+    public async Task Execute_returns_success_with_error_code_when_gateway_returns_error_code()
+    {
+        // Arrange
+        var guid = _fixture.Create<string>();
+        var type = _fixture.Create<CheckEligibilityType>();
+        var expectedStatusCode = CheckEligibilityStatus.error;
+        const string expectedErrorCode = "STE10";
+
+        _mockCheckGateway
+            .Setup(s => s.GetStatusAsync(guid, type))
+            .ReturnsAsync((
+                (CheckEligibilityStatus?)expectedStatusCode,
+                (EligibilityTier?)null,
+                expectedErrorCode));
+
+        // Act
+        var result = await _sut.Execute(guid, type);
+
+        // Assert
+        result.Data.Should().NotBeNull();
+        result.Data.Status.Should().Be(expectedStatusCode.ToString());
+        result.Data.ErrorCode.Should().Be(expectedErrorCode);
+    }
+
+    [Test]
     public async Task Execute_calls_gateway_GetStatus_with_correct_guid()
     {
         // Arrange

--- a/CheckYourEligibility.API/Adapters/DwpAdapter.cs
+++ b/CheckYourEligibility.API/Adapters/DwpAdapter.cs
@@ -368,6 +368,7 @@ public class DwpAdapter : IDwpAdapter
             string errorMessage = $"CAPI failed to match citizen. URI: {uri} | Response: {response.StatusCode}";
             _logger.LogWarning(errorMessage);
             citizenResponse.CheckEligibilityStatus = CheckEligibilityStatus.error;
+            citizenResponse.ErrorCode = "STE10";
             citizenResponse.Reason = errorMessage;
             return citizenResponse;
         }
@@ -376,6 +377,7 @@ public class DwpAdapter : IDwpAdapter
             string errorMessage = $"Exception occurred while calling CAPI citizen match endpoint. URI: {uri}";
             _logger.LogError(ex, errorMessage);
             citizenResponse.CheckEligibilityStatus = CheckEligibilityStatus.error;
+            citizenResponse.ErrorCode = "STE11";
             citizenResponse.ResponseCode = HttpStatusCode.InternalServerError;
             citizenResponse.ResponseBody = ex.Message;
             return citizenResponse;

--- a/CheckYourEligibility.API/Adapters/DwpAdapter.cs
+++ b/CheckYourEligibility.API/Adapters/DwpAdapter.cs
@@ -137,32 +137,37 @@ public class DwpAdapter : IDwpAdapter
             }
 
             // CAPI returns a non-successful code
-            _logger.LogWarning("Get CAPI citizen claim failed. uri:-{Uri} Response:- {StatusCode}",
+            _logger.LogWarning(
+                "Get CAPI citizen claim failed. uri:-{Uri} Response:- {StatusCode}",
                 _httpClient.BaseAddress + uri,
                 response.StatusCode);
 
-            var capiResponseCode = CAPIClaimResponseBase.ProcessCapiResponseCode(responseBody);
+            var capiResponseCode =
+                CAPIClaimResponseBase.ProcessCapiResponseCode(responseBody);
 
             return new CAPIClaimResponseBase
             {
                 CAPIResponseCode = capiResponseCode,
                 ResponseCode = response.StatusCode,
                 CAPIEndpoint = uri,
-                ResponseBody = responseBody
+                ResponseBody = responseBody,
+                ErrorCode = "STE20"
             };
         }
         catch (Exception ex)
         {
-                   
-            string errorMessage = $"ECE failed to POST to CAPI. uri:-{_httpClient.BaseAddress}{uri}";
+            string errorMessage =
+                $"ECE failed to POST to CAPI. uri:-{_httpClient.BaseAddress}{uri}";
+
             _logger.LogError(ex, errorMessage);
 
-            return (new CAPIClaimResponseBase
+            return new CAPIClaimResponseBase
             {
                 CAPIEndpoint = uri,
                 ResponseCode = HttpStatusCode.InternalServerError,
-                ResponseBody = ex.Message              
-            });
+                ResponseBody = ex.Message,
+                ErrorCode = "STE21"
+            };
         }
     }
 

--- a/CheckYourEligibility.API/Boundary/Responses/CAPIClaimResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/CAPIClaimResponse.cs
@@ -9,6 +9,7 @@ namespace CheckYourEligibility.API.Boundary.Responses
         public EligibilityTier? EligibilityTier { get; set; }
         public HttpStatusCode ResponseCode { get; set; }
         public long CAPIResponseCode { get; set; }
+        public string? ErrorCode { get; set; }
         public string Reason { get; set; }
         public string CAPIEndpoint { get; set; }
         public string RequestBody { get; set; }

--- a/CheckYourEligibility.API/Boundary/Responses/CheckEligibilityStatusResponse.cs
+++ b/CheckYourEligibility.API/Boundary/Responses/CheckEligibilityStatusResponse.cs
@@ -12,4 +12,6 @@ public class StatusValue
     public string Status { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public string? Tier { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string? ErrorCode { get; set; }
 }

--- a/CheckYourEligibility.API/Domain/CheckProcessData.cs
+++ b/CheckYourEligibility.API/Domain/CheckProcessData.cs
@@ -20,6 +20,7 @@ public class CheckProcessData
     public string GracePeriodEndDate { get; set; }
     public string DateOfBirth { get; set; }
     public string? EligibilityEndDate { get; set; }
+    public string? ErrorCode { get; set; }
     public string SubmissionDate { get; set; }
     public string? NationalAsylumSeekerServiceNumber { get; set; }
 

--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -268,14 +268,25 @@ public class CheckEligibilityGateway : ICheckEligibility
         }
     }
 
-    public async Task<(CheckEligibilityStatus?, EligibilityTier?)> GetStatusAsync(string guid, CheckEligibilityType type)
+    public async Task<(CheckEligibilityStatus?, EligibilityTier?, string?)> GetStatusAsync(
+        string guid,
+        CheckEligibilityType type)
     {
-        var result = await _db.CheckEligibilities.FirstOrDefaultAsync(x => x.EligibilityCheckID == guid &&
-                                                                           (type == CheckEligibilityType.None ||
-                                                                            type == x.Type) &&
-                                                                           x.IsDeleted == false);
-        if (result != null) return (result.Status, result.Tier);
-        return (null, null);
+        var result = await _db.CheckEligibilities.FirstOrDefaultAsync(x =>
+            x.EligibilityCheckID == guid &&
+            (type == CheckEligibilityType.None || type == x.Type) &&
+            x.IsDeleted == false);
+
+        if (result != null)
+        {
+            var checkData = string.IsNullOrWhiteSpace(result.CheckData)
+                ? null
+                : JsonConvert.DeserializeObject<CheckProcessData>(result.CheckData);
+
+            return (result.Status, result.Tier, checkData?.ErrorCode);
+        }
+
+        return (null, null, null);
     }
 
     public async Task<CheckEligibilityBulkDeleteResponseData> DeleteByBulkCheckId(string bulkCheckId)

--- a/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
@@ -441,8 +441,7 @@ public class CheckingEngineGateway : ICheckingEngine
 
                         checkStatusResult = capiClaimResponse.CheckEligibilityStatus;
                         checkTierResult = capiClaimResponse.EligibilityTier;
-                        checkData.ErrorCode = capiClaimResponse.ErrorCode;
-                        result.CheckData = JsonConvert.SerializeObject(checkData);
+                        checkData.ErrorCode = capiClaimResponse.ErrorCode;                        
 
                         source = ProcessEligibilityCheckSource.DWP;
 
@@ -493,13 +492,20 @@ public class CheckingEngineGateway : ICheckingEngine
 
         if (result.Type == CheckEligibilityType.FreeSchoolMeals && checkStatusResult == CheckEligibilityStatus.eligible)
         {
-            checkData.EligibilityEndDate = (EligibilityCheckHelper.GetEligibilityEndDateFSM(result.Created)).ToString("yyyy-MM-dd");
-            result.CheckData = JsonConvert.SerializeObject(checkData);
+            checkData.EligibilityEndDate = (EligibilityCheckHelper.GetEligibilityEndDateFSM(result.Created)).ToString("yyyy-MM-dd");            
         }
 
         result.Status = checkStatusResult;
         result.Tier = checkTierResult;
         result.Updated = DateTime.UtcNow;
+
+        if (checkStatusResult == CheckEligibilityStatus.error &&
+            string.IsNullOrWhiteSpace(checkData.ErrorCode))
+        {
+            checkData.ErrorCode = "STE50";
+        }
+
+        result.CheckData = JsonConvert.SerializeObject(checkData);
 
         if (checkStatusResult == CheckEligibilityStatus.error)
         {

--- a/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckingEngineGateway.cs
@@ -441,6 +441,9 @@ public class CheckingEngineGateway : ICheckingEngine
 
                         checkStatusResult = capiClaimResponse.CheckEligibilityStatus;
                         checkTierResult = capiClaimResponse.EligibilityTier;
+                        checkData.ErrorCode = capiClaimResponse.ErrorCode;
+                        result.CheckData = JsonConvert.SerializeObject(checkData);
+
                         source = ProcessEligibilityCheckSource.DWP;
 
                         var capiAudit = new CAPIAudit(

--- a/CheckYourEligibility.API/Gateways/Interfaces/ICheckEligibility.cs
+++ b/CheckYourEligibility.API/Gateways/Interfaces/ICheckEligibility.cs
@@ -14,7 +14,9 @@ public interface ICheckEligibility
     Task<T?> GetItem<T>(string guid, CheckEligibilityType type, bool isBatchRecord = false)
         where T : CheckEligibilityItem;
 
-    Task<(CheckEligibilityStatus?,EligibilityTier?)> GetStatusAsync(string guid, CheckEligibilityType type);
+    Task<(CheckEligibilityStatus?, EligibilityTier?, string?)> GetStatusAsync(
+        string guid,
+        CheckEligibilityType type);
 
     Task<CheckEligibilityStatusResponse> UpdateEligibilityCheckStatus(string guid, EligibilityCheckStatusData data, EligibilityCheckContext dbContextFactory = null);
     Task<CheckEligibilityBulkDeleteResponseData> DeleteByBulkCheckId(string bulkCheckId);

--- a/CheckYourEligibility.API/Usecases/GetEligibilityCheckStatusUseCase.cs
+++ b/CheckYourEligibility.API/Usecases/GetEligibilityCheckStatusUseCase.cs
@@ -39,7 +39,7 @@ public class GetEligibilityCheckStatusUseCase : IGetEligibilityCheckStatusUseCas
     {
         if (string.IsNullOrEmpty(guid)) throw new ValidationException(null, "Invalid Request, check ID is required.");
 
-        var (status,tier) = await _checkGateway.GetStatusAsync(guid, type);
+        var (status, tier, errorCode) = await _checkGateway.GetStatusAsync(guid, type);
         if (status == null)
         {
             _logger.LogWarning(
@@ -55,7 +55,8 @@ public class GetEligibilityCheckStatusUseCase : IGetEligibilityCheckStatusUseCas
             Data = new StatusValue
             {
                 Status = status.Value.ToString(),
-                Tier = tier?.ToString()
+                Tier = tier?.ToString(),
+                ErrorCode = errorCode
             }
         };
     }


### PR DESCRIPTION
### Summary

- Added support for persisting technical error codes for eligibility checks.
- Exposed persisted error codes through the status endpoint.
- Added DWP error code mappings for matcher and claims failures (STE10, STE11, STE20, STE21).
- Added fallback assignment of STE50 when processing completes with an error but no specific code is available.
- Added unit tests covering specific and fallback error code behaviour.