### PR TITLE
follow up additions

### DIFF
--- a/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
+++ b/CheckYourEligibility.API/Gateways/CheckEligibilityGateway.cs
@@ -79,12 +79,18 @@ public class CheckEligibilityGateway : ICheckEligibility
 
                     var elapsedTime = bulkCheck.CompletedDate.Value - bulkCheck.SubmittedDate;
 
-                    _logger.LogInformation(
-                        "BulkCheckFinished BulkCheckId={BulkCheckId} Status={Status} CompletedDate={CompletedDate} ElapsedMilliseconds={ElapsedMilliseconds}",
-                        bulkCheck.BulkCheckID,
-                        bulkCheck.Status,
-                        bulkCheck.CompletedDate,
-                        elapsedTime.TotalMilliseconds);
+                    var logEvent = JsonConvert.SerializeObject(new
+                    {
+                        BulkCheckId = bulkCheck.BulkCheckID,
+                        Status = bulkCheck.Status.ToString(),
+                        SubmittedDate = bulkCheck.SubmittedDate,
+                        CompletedDate = bulkCheck.CompletedDate,
+                        ElapsedMilliseconds = elapsedTime.TotalMilliseconds,
+                        NumberOfRecords = bulkCheck.NumberOfRecords,
+                        OrganisationID = bulkCheck.OrganisationID
+                    });
+
+                    _logger.LogInformation("{BulkCheckEvent}", logEvent);
                 }
             }
         }
@@ -110,12 +116,18 @@ public class CheckEligibilityGateway : ICheckEligibility
 
                     var elapsedTime = bulkCheck.CompletedDate.Value - bulkCheck.SubmittedDate;
 
-                    _logger.LogInformation(
-                        "BulkCheckFinished BulkCheckId={BulkCheckId} Status={Status} CompletedDate={CompletedDate} ElapsedMilliseconds={ElapsedMilliseconds}",
-                        bulkCheck.BulkCheckID,
-                        bulkCheck.Status,
-                        bulkCheck.CompletedDate,
-                        elapsedTime.TotalMilliseconds);
+                    var logEvent = JsonConvert.SerializeObject(new
+                    {
+                        BulkCheckId = bulkCheck.BulkCheckID,
+                        Status = bulkCheck.Status.ToString(),
+                        SubmittedDate = bulkCheck.SubmittedDate,
+                        CompletedDate = bulkCheck.CompletedDate,
+                        ElapsedMilliseconds = elapsedTime.TotalMilliseconds,
+                        NumberOfRecords = bulkCheck.NumberOfRecords,
+                        OrganisationID = bulkCheck.OrganisationID
+                    });
+
+                    _logger.LogInformation("{BulkCheckEvent}", logEvent);
                 }
             }
             catch (Exception statusUpdateEx)


### PR DESCRIPTION
## Summary

Follow-up to ELIG-3344.

Updates the remaining bulk check closure paths in `CheckEligibilityGateway` to use the agreed JSON logging format requested for Splunk.

## Changes
- Updated the immediate-completion bulk check path.
- Updated the bulk check failure path.
- Logs are now emitted as JSON.
- Added:
  - SubmittedDate
  - CompletedDate
  - NumberOfRecords
  - OrganisationID
- Dates are emitted in ISO 8601 format via JSON serialization.

## Reason

The previous PR updated the completion logging in `ProcessEligibilityBulkCheckUseCase`, however these two gateway closure scenarios were inadvertently left using the previous log format. This PR aligns all three bulk check completion/failure paths with the agreed logging format.