### PR TITLE
ELIG-3475 Resolve Dependabot vulnerabilities in API test dependencies

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -321,9 +321,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.0.tgz",
-      "integrity": "sha512-wGTQfwDMMMiz/muFw4YbCLwTh0uZsXKK+6zWBzftADpitSi6iM62C8GzEhNcng2srUiGPksOriQkA8zakW2R0g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.1.tgz",
+      "integrity": "sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -339,7 +339,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.14.1",
+        "qs": "^6.15.2",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^5.0.0",
         "tunnel-agent": "^0.6.0"
@@ -1080,6 +1080,32 @@
       },
       "peerDependencies": {
         "cypress": ">=3"
+      }
+    },
+    "node_modules/cypress/node_modules/systeminformation": {
+      "version": "5.31.17",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.17.tgz",
+      "integrity": "sha512-TvFA9iwDWlMjqZVlKIJ0Cy+Zgm9ttlMx0SMRwJDMNKyhlEKWBMb3+WRwDi/3dvHdWbexpos4Osp4U49p5WjB5g==",
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
     "node_modules/cypress/node_modules/tslib": {
@@ -1894,6 +1920,27 @@
         "npm": ">=6"
       }
     },
+    "node_modules/jsonwebtoken/node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/jws": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.2",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/jsprim": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
@@ -1934,27 +1981,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/listr2": {
@@ -2160,9 +2186,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -2290,9 +2316,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2309,7 +2335,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2360,9 +2386,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2722,32 +2748,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/systeminformation": {
-      "version": "5.31.6",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
-      "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
-      "license": "MIT",
-      "os": [
-        "darwin",
-        "linux",
-        "win32",
-        "freebsd",
-        "openbsd",
-        "netbsd",
-        "sunos",
-        "android"
-      ],
-      "bin": {
-        "systeminformation": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "Buy me a coffee",
-        "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
     "node_modules/throttleit": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,17 +8,16 @@
     "typescript": "^5.4.5"
   },
   "overrides": {
-  "jsonwebtoken": {
-    "jws": "3.2.3"
-  },
-  "jws": "4.0.1"
+    "jsonwebtoken": {
+      "jws": "3.2.3"
+    },
+    "jws": "4.0.1",
+    "qs": "6.15.2",
+    "systeminformation": "5.31.17"
   },
   "scripts": {
     "e2e:electron": "cypress run --browser electron",
     "combine:reports": "jrm results/combined-report.xml \"results/*.xml\""
-  },
-  "overrides": {
-  "qs": "6.15.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.2.0",


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2><p>Resolves the Dependabot vulnerabilities affecting the API Cypress test dependency tree in <code inline="">tests/package-lock.json</code>.</p><p>The existing Cypress version remains unchanged at <code inline="">15.15.0</code>. Only compatible transitive dependency updates have been applied.</p><p>A newly published PostCSS vulnerability was identified during the clean-install baseline using <code inline="">npm audit</code>. Following discussion with Jim, this was added to the scope because it affects the same manifest and lockfile.</p><h2>Dependency changes</h2>
Dependency | Previous | Updated | Dependency path
-- | -- | -- | --
@cypress/request | 4.0.0 | 4.0.1 | cypress → @cypress/request
qs | 6.15.0 | 6.15.2 | cypress → @cypress/request → qs
systeminformation | 5.31.6 | 5.31.17 | cypress → systeminformation
postcss | 8.5.15 | 8.5.23 | cypress-plugin-api → vue → @vue/compiler-sfc → postcss
nanoid | 3.3.15 | 3.3.16 | Required by the updated PostCSS version

<p>The duplicate <code inline="">overrides</code> properties in <code inline="">tests/package.json</code> were consolidated so the existing <code inline="">jsonwebtoken</code>/<code inline="">jws</code> overrides and the updated security overrides are applied together.</p><p>No Cypress upgrade was made.</p><h2>Vulnerabilities resolved</h2><ul><li><p><code inline="">systeminformation</code> — GHSA-5xpp-75jx-m839 / CVE-2026-50289</p></li><li><p><code inline="">qs</code> — GHSA-q8mj-m7cp-5q26 / CVE-2026-8723</p></li><li><p><code inline="">postcss</code> — GHSA-r28c-9q8g-f849</p></li></ul><h2>Breaking-change assessment</h2><p>The changes are limited to compatible transitive patch releases within the dependency ranges already permitted by the existing parent packages. Cypress remains at <code inline="">15.15.0</code>, so no Cypress migration or documentation updates are required.</p><h2>Verification</h2><ul><li><p>Clean <code inline="">npm ci</code>: passed</p></li><li><p><code inline="">npm audit</code>: 0 vulnerabilities</p></li><li><p>Cypress package version: 15.15.0</p></li><li><p>Cypress binary version: 15.15.0</p></li><li><p><code inline="">npx cypress verify</code>: passed</p></li><li><p>API import Cypress specs: passed</p></li><li><p>Release build: passed with 0 errors</p></li><li><p>.NET automated tests: 813 passed, 0 failed, 3 skipped</p></li></ul><p>The complete Cypress suite was attempted locally, but the Application tests could not be treated as reliable regression evidence because of the known current CAPI outage in DEV/TEST. The eligibility check did not produce a qualifying FreeSchoolMeals check, causing application creation to return 400 and subsequent Get/Update tests to fail. Jim confirmed that this symptom could be caused by the CAPI outage rather than the tests or these dependency changes.</p><p>The full suite will also be verified through the PR pipeline and can be rerun once CAPI is stable.</p><h2>Post-merge verification</h2><p>After merging into <code inline="">main</code>, confirm that GitHub closes the Dependabot alerts associated with <code inline="">tests/package-lock.json</code>.</p></body></html><!--EndFragment-->
</body>
</html>

Full API Cypress suite: passed in the PR pipeline after merging the latest main, including the corrected response-property assertions.